### PR TITLE
refactor: simplify `IsCompatibleWith` method signature

### DIFF
--- a/src/Nethermind.Arbitrum.Test/Rpc/DigestMessage/NitroL2MessageParserTests.cs
+++ b/src/Nethermind.Arbitrum.Test/Rpc/DigestMessage/NitroL2MessageParserTests.cs
@@ -8,6 +8,7 @@ using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Int256;
 using Nethermind.Specs.ChainSpecStyle;
+using Nethermind.Specs.Test.ChainSpecStyle;
 using static NUnit.Framework.Assert;
 
 namespace Nethermind.Arbitrum.Test.Rpc.DigestMessage
@@ -310,9 +311,8 @@ namespace Nethermind.Arbitrum.Test.Rpc.DigestMessage
         {
             var initMessage = CreateInitMessageWithDefaults();
             var chainSpec = CreateChainSpec(TestChainId);
-            var localArbitrumParams = CreateArbitrumChainSpecEngineParameters();
 
-            var result = initMessage.IsCompatibleWith(chainSpec, localArbitrumParams);
+            var result = initMessage.IsCompatibleWith(chainSpec);
 
             result.Should().BeNull();
         }
@@ -323,9 +323,8 @@ namespace Nethermind.Arbitrum.Test.Rpc.DigestMessage
             const ulong mismatchedChainId = 999999;
             var initMessage = CreateInitMessageWithDefaults();
             var mismatchedChainSpec = CreateChainSpec(mismatchedChainId);
-            var localArbitrumParams = CreateArbitrumChainSpecEngineParameters();
 
-            var result = initMessage.IsCompatibleWith(mismatchedChainSpec, localArbitrumParams);
+            var result = initMessage.IsCompatibleWith(mismatchedChainSpec);
 
             var expectedError = $"Chain ID mismatch: L1 init message has chain ID {TestChainId}, but local chainspec expects {mismatchedChainId}";
             result.Should().BeEquivalentTo(expectedError);
@@ -336,10 +335,9 @@ namespace Nethermind.Arbitrum.Test.Rpc.DigestMessage
         {
             const uint mismatchedVersion = 99;
             var initMessage = CreateInitMessageWithDefaults();
-            var chainSpec = CreateChainSpec(TestChainId);
-            var mismatchedParams = CreateArbitrumChainSpecEngineParameters(initialArbOSVersion: mismatchedVersion);
+            var chainSpec = CreateChainSpec(TestChainId, mismatchedVersion);
 
-            var result = initMessage.IsCompatibleWith(chainSpec, mismatchedParams);
+            var result = initMessage.IsCompatibleWith(chainSpec);
 
             var expectedError = $"Initial ArbOS version mismatch: L1 init message has version {TestInitialArbOSVersion}, but local chainspec expects {mismatchedVersion}";
             result.Should().BeEquivalentTo(expectedError);
@@ -436,7 +434,18 @@ namespace Nethermind.Arbitrum.Test.Rpc.DigestMessage
 
         private static ChainSpec CreateChainSpec(ulong chainId)
         {
-            return new ChainSpec { ChainId = chainId };
+            var chainSpec = new ChainSpec { ChainId = chainId };
+            var arbitrumParams = CreateArbitrumChainSpecEngineParameters();
+            chainSpec.EngineChainSpecParametersProvider = new TestChainSpecParametersProvider(arbitrumParams);
+            return chainSpec;
+        }
+
+        private static ChainSpec CreateChainSpec(ulong chainId, uint initialArbOSVersion)
+        {
+            var chainSpec = new ChainSpec { ChainId = chainId };
+            var arbitrumParams = CreateArbitrumChainSpecEngineParameters(initialArbOSVersion);
+            chainSpec.EngineChainSpecParametersProvider = new TestChainSpecParametersProvider(arbitrumParams);
+            return chainSpec;
         }
 
         private static ArbitrumChainSpecEngineParameters CreateArbitrumChainSpecEngineParameters(

--- a/src/Nethermind.Arbitrum/Data/ParsedInitMessage.cs
+++ b/src/Nethermind.Arbitrum/Data/ParsedInitMessage.cs
@@ -24,7 +24,7 @@ namespace Nethermind.Arbitrum.Data
 
         public byte[]? SerializedChainConfig = serializedChainConfig;
 
-        public string? IsCompatibleWith(ChainSpec localChainSpec, ArbitrumChainSpecEngineParameters localArbitrumParams)
+        public string? IsCompatibleWith(ChainSpec localChainSpec)
         {
             // Chain ID must match exactly
             if (ChainId != localChainSpec.ChainId)
@@ -36,6 +36,8 @@ namespace Nethermind.Arbitrum.Data
             if (ChainConfigSpec?.ArbitrumChainParams != null)
             {
                 var l1ArbitrumParams = ChainConfigSpec.ArbitrumChainParams;
+                var localArbitrumParams = localChainSpec.EngineChainSpecParametersProvider
+                    .GetChainSpecParameters<ArbitrumChainSpecEngineParameters>();
 
                 // Key Arbitrum parameters must match
                 if (localArbitrumParams.EnableArbOS.HasValue &&

--- a/src/Nethermind.Arbitrum/Genesis/ArbitrumGenesisLoader.cs
+++ b/src/Nethermind.Arbitrum/Genesis/ArbitrumGenesisLoader.cs
@@ -45,10 +45,7 @@ public class ArbitrumGenesisLoader(
 
     private void ValidateInitMessage()
     {
-        var localArbitrumParams = chainSpec.EngineChainSpecParametersProvider
-            .GetChainSpecParameters<ArbitrumChainSpecEngineParameters>();
-
-        var compatibilityError = initMessage.IsCompatibleWith(chainSpec, localArbitrumParams);
+        var compatibilityError = initMessage.IsCompatibleWith(chainSpec);
         if (compatibilityError != null)
         {
             throw new InvalidOperationException(


### PR DESCRIPTION
Remove `ArbitrumChainSpecEngineParameters` parameter from `IsCompatibleWith` method by retrieving it directly from the `ChainSpec`'s `EngineChainSpecParametersProvider`.

- Update `ParsedInitMessage.IsCompatibleWith` to accept only `ChainSpec`
- Retrieve `ArbitrumChainSpecEngineParameters` internally when needed