### PR TITLE
Incorrect gas cost for EIP-1559 transactions when dropping tip

### DIFF
--- a/src/Nethermind.Arbitrum/Execution/ArbitrumTransactionProcessor.cs
+++ b/src/Nethermind.Arbitrum/Execution/ArbitrumTransactionProcessor.cs
@@ -98,7 +98,7 @@ namespace Nethermind.Arbitrum.Execution
             {
                 originalGasPrice = tx.GasPrice;
                 //causes premium to be set to 0 for both legacy and eip-1559 transactions
-                tx.GasPrice = tx.Supports1559 ? (UInt256)0 : _currentHeader!.BaseFeePerGas;
+                tx.GasPrice = tx.Supports1559 ? UInt256.Zero : _currentHeader!.BaseFeePerGas;
             }
             TransactionResult evmResult = base.Execute(tx, tracer, opts);
 


### PR DESCRIPTION
When executing `ShouldDropTip` for an eip-1559 transaction, setting `GasPrice` to base fee, effectively doubles gas fee for transaction.
This code change sets `GasPrice` to `0` for eip-1559 (setting `MaxPriorityFeePerGas` also)