### PR TITLE
Disable eip-4895

### DIFF
--- a/src/Nethermind.Arbitrum.Test/Infrastructure/FullChainSimulationChainSpecProvider.cs
+++ b/src/Nethermind.Arbitrum.Test/Infrastructure/FullChainSimulationChainSpecProvider.cs
@@ -118,7 +118,6 @@ public static class FullChainSimulationChainSpecProvider
             Eip3651TransitionTimestamp = 0x63fd7d60,
             Eip3855TransitionTimestamp = 0x63fd7d60,
             Eip3860TransitionTimestamp = 0x63fd7d60,
-            Eip4895TransitionTimestamp = 0x63fd7d60,
             Eip1153TransitionTimestamp = 0x65b97d60,
             Eip5656TransitionTimestamp = 0x65b97d60,
             Eip6780TransitionTimestamp = 0x65b97d60,

--- a/src/Nethermind.Arbitrum/Properties/chainspec/arbitrum-local.json
+++ b/src/Nethermind.Arbitrum/Properties/chainspec/arbitrum-local.json
@@ -50,7 +50,6 @@
     "terminalTotalDifficulty": "3C6568F12E8000",
     "mergeForkIdTransition": "0x0",
     "beaconChainGenesisTimestamp": "0x62b07d60",
-    "eip4895TransitionTimestamp": "0x63FD7D60",
     "eip3855TransitionTimestamp": "0x63FD7D60",
     "eip3651TransitionTimestamp": "0x63FD7D60",
     "eip3860TransitionTimestamp": "0x63FD7D60",


### PR DESCRIPTION
Disable eip-4895 for dev chain simulation - removes `WithdrawalsRoot` from block header - to match nitro.