### PR TITLE
Arbos storage - set empty bytes at 1st offset

### DIFF
--- a/src/Nethermind.Arbitrum.Test/Arbos/ArbosStorageTests.cs
+++ b/src/Nethermind.Arbitrum.Test/Arbos/ArbosStorageTests.cs
@@ -195,6 +195,7 @@ public partial class ArbosStorageTests
         actual.Should().Be((ulong)length);
     }
 
+    [TestCase(0)]
     [TestCase(4)]
     [TestCase(16)]
     [TestCase(32)]
@@ -213,6 +214,7 @@ public partial class ArbosStorageTests
         actual.Should().BeEquivalentTo(value);
     }
 
+    [TestCase(0)]
     [TestCase(32)]
     [TestCase(100)]
     public void ClearBytes_Always_ClearsStorage(int length)

--- a/src/Nethermind.Arbitrum/Arbos/Storage/ArbosStorage.cs
+++ b/src/Nethermind.Arbitrum/Arbos/Storage/ArbosStorage.cs
@@ -127,10 +127,7 @@ public class ArbosStorage
             offset++;
         }
 
-        if (span.Length > 0)
-        {
-            Set(offset, Hash256.FromBytesWithPadding(span));
-        }
+        Set(offset, Hash256.FromBytesWithPadding(span));
     }
 
     public byte[] GetBytes()


### PR DESCRIPTION
Arbos storage - set empty bytes at 1st offset to mimic nitro's behaviour