### PR TITLE
fix: MerkleAccumulator.Append uses KeccakHashWithCost

### DIFF
--- a/src/Nethermind.Arbitrum.Test/Arbos/ArbosStorageTests.cs
+++ b/src/Nethermind.Arbitrum.Test/Arbos/ArbosStorageTests.cs
@@ -268,7 +268,7 @@ public partial class ArbosStorageTests
         ReadOnlySpan<byte> data = RandomNumberGenerator.GetBytes(bytesLength);
         ValueHash256 expected = Keccak.Compute(data);
 
-        ValueHash256 actual = storage.CalculateHash(data);
+        ValueHash256 actual = storage.KeccakHashWithCost(data);
 
         systemBurner.Burned.Should().Be(burnedCost);
         actual.Should().Be(expected);

--- a/src/Nethermind.Arbitrum/Arbos/Storage/ArbosStorage.cs
+++ b/src/Nethermind.Arbitrum/Arbos/Storage/ArbosStorage.cs
@@ -209,9 +209,9 @@ public class ArbosStorage
         return _db.GetCodeHash(address);
     }
 
-    public ValueHash256 CalculateHash(ReadOnlySpan<byte> memory)
+    public ValueHash256 KeccakHashWithCost(ReadOnlySpan<byte> memory)
     {
-        var words = (ulong)memory.Length / 32 + 1;
+        ulong words = Math.Utils.Div32Ceiling((ulong)memory.Length);
         Burner.Burn(KeccakBaseCost + KeccakWordCost * words);
         return ValueKeccak.Compute(memory);
     }

--- a/src/Nethermind.Arbitrum/Arbos/Storage/Blockhashes.cs
+++ b/src/Nethermind.Arbitrum/Arbos/Storage/Blockhashes.cs
@@ -42,7 +42,7 @@ public class Blockhashes(ArbosStorage storage)
                 ToLittleEndianByteArray(nextNumber).CopyTo(buffer[32..]);
             }
             //burns cost
-            var newHash = storage.CalculateHash(buffer);
+            var newHash = storage.KeccakHashWithCost(buffer);
             storage.Set(1 + (nextNumber % 256), newHash);
         }
 

--- a/src/Nethermind.Arbitrum/Arbos/Storage/MerkleAccumulator.cs
+++ b/src/Nethermind.Arbitrum/Arbos/Storage/MerkleAccumulator.cs
@@ -50,14 +50,14 @@ public class MerkleAccumulator(ArbosStorage storage)
                         soFar.Bytes.CopyTo(buffer);
                         emptyBytes.CopyTo(buffer[ValueHash256.MemorySize..]);
 
-                        soFar = storage.CalculateHash(buffer);
+                        soFar = storage.KeccakHashWithCost(buffer);
                         capacityInHash *= 2;
                     }
 
                     partial.Bytes.CopyTo(buffer);
                     soFar.Bytes.CopyTo(buffer[ValueHash256.MemorySize..]);
 
-                    soFar = storage.CalculateHash(buffer);
+                    soFar = storage.KeccakHashWithCost(buffer);
                     capacityInHash = 2 * capacity;
                 }
             }
@@ -92,7 +92,7 @@ public class MerkleAccumulator(ArbosStorage storage)
             }
 
             // Combine and carry to next level
-            soFar = ValueKeccak.Compute(Bytes.Concat(thisLevel.Bytes, soFar.Bytes));
+            soFar = storage.KeccakHashWithCost(Bytes.Concat(thisLevel.Bytes, soFar.Bytes));
             SetPartial(level, default); // Clear this level
 
             level += 1;


### PR DESCRIPTION
After [PR](https://github.com/NethermindEth/nethermind-arbitrum/pull/160) (fixing failing block 552), execution fails at block 594.

The issue is a difference of 42 gas units spent in nitro for [tx](https://sepolia.arbiscan.io/tx/0xc047adf99bb53b2d643fab4b037d03080017ecbaab805c9ceee78cebb7b17234) that are not spent in NMC.

The cause is the `MerkleAccumulator.Append` function that was using the base/normal Keccak hash function, without inducing any gas burnt for the hash computation when it should. The fix suggests to use the existing `CalculateHash` renamed `KeccakHashWithCost` to make it more explicit:
- what kind of hash is being computed
- some cost is induced