### PR TITLE
fix: Use lazy initialization to avoid opening uninitialized arbos state

### DIFF
--- a/src/Nethermind.Arbitrum/ArbitrumPlugin.cs
+++ b/src/Nethermind.Arbitrum/ArbitrumPlugin.cs
@@ -29,6 +29,7 @@ using Nethermind.JsonRpc.Modules.Eth.FeeHistory;
 using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Specs.ChainSpecStyle;
+using Nethermind.State;
 
 namespace Nethermind.Arbitrum;
 
@@ -199,13 +200,14 @@ public class ArbitrumModule(ChainSpec chainSpec) : Module
                 ArbosState? arbosState = ctx.ResolveOptional<ArbosState>();
                 if (arbosState is not null)
                 {
-                    IArbosVersionProvider arbosVersionProviderFactory() => arbosState;
-                    return new ArbitrumChainSpecBasedSpecProvider(chainSpec, arbosVersionProviderFactory, ctx.Resolve<ILogManager>());
+                    IWorldState worldState = ctx.Resolve<IWorldState>();
+                    ArbosStateVersionProvider arbosVersionProvider = new(worldState);
+                    return new ArbitrumChainSpecBasedSpecProvider(chainSpec, arbosVersionProvider, ctx.Resolve<ILogManager>());
                 }
                 else
                 {
                     ArbitrumChainSpecEngineParameters chainSpecParams = ctx.Resolve<ArbitrumChainSpecEngineParameters>();
-                    IArbosVersionProvider arbosVersionProviderFactory() => chainSpecParams;
+                    ChainSpecVersionProvider arbosVersionProviderFactory = new(chainSpecParams);
                     return new ArbitrumChainSpecBasedSpecProvider(chainSpec, arbosVersionProviderFactory, ctx.Resolve<ILogManager>());
                 }
             })

--- a/src/Nethermind.Arbitrum/Arbos/ArbosState.cs
+++ b/src/Nethermind.Arbitrum/Arbos/ArbosState.cs
@@ -12,12 +12,7 @@ using Nethermind.Arbitrum.Arbos.Programs;
 
 namespace Nethermind.Arbitrum.Arbos;
 
-public interface IArbosVersionProvider
-{
-    ulong CurrentArbosVersion { get; }
-}
-
-public class ArbosState : IArbosVersionProvider
+public class ArbosState
 {
     private readonly ILogger _logger;
 

--- a/src/Nethermind.Arbitrum/Arbos/ArbosVersionProvider.cs
+++ b/src/Nethermind.Arbitrum/Arbos/ArbosVersionProvider.cs
@@ -1,0 +1,24 @@
+using Nethermind.Arbitrum.Arbos.Storage;
+using Nethermind.Arbitrum.Config;
+using Nethermind.State;
+
+namespace Nethermind.Arbitrum.Arbos;
+
+public interface IArbosVersionProvider
+{
+    ulong Get();
+}
+
+public class ArbosStateVersionProvider(IWorldState state) : IArbosVersionProvider
+{
+    public ulong Get()
+    {
+        ArbosStorage backingStorage = new(state, new ZeroGasBurner(), ArbosAddresses.ArbosSystemAccount);
+        return backingStorage.GetULong(ArbosStateOffsets.VersionOffset);
+    }
+}
+
+public class ChainSpecVersionProvider(ArbitrumChainSpecEngineParameters parameters) : IArbosVersionProvider
+{
+    public ulong Get() => parameters.InitialArbOSVersion ?? 0;
+}

--- a/src/Nethermind.Arbitrum/Config/ArbitrumChainSpecBasedSpecProvider.cs
+++ b/src/Nethermind.Arbitrum/Config/ArbitrumChainSpecBasedSpecProvider.cs
@@ -11,42 +11,36 @@ namespace Nethermind.Arbitrum.Config;
 
 public sealed class ArbitrumChainSpecBasedSpecProvider(
     ChainSpec chainSpec,
-    Func<IArbosVersionProvider> arbosVersionProviderFactory,
+    IArbosVersionProvider arbosVersionProvider,
     ILogManager logManager = null!)
     : ChainSpecBasedSpecProvider(chainSpec, logManager)
 {
-    private IArbosVersionProvider? _arbosVersionProvider;
-
     // Even though we mutate the spec, this is fine as each scope has its own spec provider instance
     public sealed override IReleaseSpec GetSpec(ForkActivation activation)
     {
-        // Use lazy initialization because opening arbos in ArbitrumInitializeBlockchain fails
-        // as it has not been initialized yet.
-        _arbosVersionProvider ??= arbosVersionProviderFactory();
-
         IReleaseSpec spec = base.GetSpec(activation);
 
         ReleaseSpec mutableSpec = (ReleaseSpec)spec;
 
         // shanghai
-        mutableSpec.IsEip4895Enabled = _arbosVersionProvider.CurrentArbosVersion >= ArbosVersion.Eleven;
-        mutableSpec.IsEip3651Enabled = _arbosVersionProvider.CurrentArbosVersion >= ArbosVersion.Eleven;
-        mutableSpec.IsEip3855Enabled = _arbosVersionProvider.CurrentArbosVersion >= ArbosVersion.Eleven;
-        mutableSpec.IsEip3860Enabled = _arbosVersionProvider.CurrentArbosVersion >= ArbosVersion.Eleven;
+        mutableSpec.IsEip4895Enabled = arbosVersionProvider.Get() >= ArbosVersion.Eleven;
+        mutableSpec.IsEip3651Enabled = arbosVersionProvider.Get() >= ArbosVersion.Eleven;
+        mutableSpec.IsEip3855Enabled = arbosVersionProvider.Get() >= ArbosVersion.Eleven;
+        mutableSpec.IsEip3860Enabled = arbosVersionProvider.Get() >= ArbosVersion.Eleven;
 
         // cancun
-        mutableSpec.IsEip4844Enabled = _arbosVersionProvider.CurrentArbosVersion >= ArbosVersion.Twenty;
-        mutableSpec.IsEip1153Enabled = _arbosVersionProvider.CurrentArbosVersion >= ArbosVersion.Twenty;
-        mutableSpec.IsEip4788Enabled = _arbosVersionProvider.CurrentArbosVersion >= ArbosVersion.Twenty;
-        mutableSpec.IsEip5656Enabled = _arbosVersionProvider.CurrentArbosVersion >= ArbosVersion.Twenty;
-        mutableSpec.IsEip6780Enabled = _arbosVersionProvider.CurrentArbosVersion >= ArbosVersion.Twenty;
+        mutableSpec.IsEip4844Enabled = arbosVersionProvider.Get() >= ArbosVersion.Twenty;
+        mutableSpec.IsEip1153Enabled = arbosVersionProvider.Get() >= ArbosVersion.Twenty;
+        mutableSpec.IsEip4788Enabled = arbosVersionProvider.Get() >= ArbosVersion.Twenty;
+        mutableSpec.IsEip5656Enabled = arbosVersionProvider.Get() >= ArbosVersion.Twenty;
+        mutableSpec.IsEip6780Enabled = arbosVersionProvider.Get() >= ArbosVersion.Twenty;
 
         // prague
-        mutableSpec.IsEip7702Enabled = _arbosVersionProvider.CurrentArbosVersion >= ArbosVersion.Forty;
-        mutableSpec.IsEip7251Enabled = _arbosVersionProvider.CurrentArbosVersion >= ArbosVersion.Forty;
-        mutableSpec.IsEip2537Enabled = _arbosVersionProvider.CurrentArbosVersion >= ArbosVersion.Forty;
-        mutableSpec.IsEip7002Enabled = _arbosVersionProvider.CurrentArbosVersion >= ArbosVersion.Forty;
-        mutableSpec.IsEip6110Enabled = _arbosVersionProvider.CurrentArbosVersion >= ArbosVersion.Forty;
+        mutableSpec.IsEip7702Enabled = arbosVersionProvider.Get() >= ArbosVersion.Forty;
+        mutableSpec.IsEip7251Enabled = arbosVersionProvider.Get() >= ArbosVersion.Forty;
+        mutableSpec.IsEip2537Enabled = arbosVersionProvider.Get() >= ArbosVersion.Forty;
+        mutableSpec.IsEip7002Enabled = arbosVersionProvider.Get() >= ArbosVersion.Forty;
+        mutableSpec.IsEip6110Enabled = arbosVersionProvider.Get() >= ArbosVersion.Forty;
 
         return mutableSpec;
     }

--- a/src/Nethermind.Arbitrum/Config/ArbitrumChainSpecEngineParameters.cs
+++ b/src/Nethermind.Arbitrum/Config/ArbitrumChainSpecEngineParameters.cs
@@ -38,7 +38,7 @@ namespace Nethermind.Arbitrum.Config;
 /// }
 /// </code>
 /// </remarks>
-public class ArbitrumChainSpecEngineParameters : IChainSpecEngineParameters, IArbosVersionProvider
+public class ArbitrumChainSpecEngineParameters : IChainSpecEngineParameters
 {
     public const string ArbitrumEngineName = "Arbitrum";
 

--- a/src/Nethermind.Arbitrum/Config/ArbitrumInitializeBlockchain.cs
+++ b/src/Nethermind.Arbitrum/Config/ArbitrumInitializeBlockchain.cs
@@ -37,14 +37,10 @@ public class ArbitrumInitializeBlockchain(ArbitrumNethermindApi api) : Initializ
         if (api.BlockTree is null) throw new StepDependencyException(nameof(api.BlockTree));
         if (api.WorldStateManager is null) throw new StepDependencyException(nameof(api.WorldStateManager));
 
-        IArbosVersionProvider arbosVersionProviderFactory() =>
-            ArbosState.OpenArbosState(worldState, new SystemBurner(), api.LogManager.GetClassLogger());
-
         ArbitrumChainSpecBasedSpecProvider specProvider = new(
             api.Context.Resolve<ChainSpec>(),
-            arbosVersionProviderFactory,
-            api.LogManager
-        );
+            new ArbosStateVersionProvider(worldState),
+            api.LogManager);
 
         BlockhashProvider blockhashProvider = new(
             api.BlockTree, specProvider, worldState, api.LogManager);
@@ -61,14 +57,10 @@ public class ArbitrumInitializeBlockchain(ArbitrumNethermindApi api) : Initializ
     {
         if (api.BlockTree is null) throw new StepDependencyException(nameof(api.BlockTree));
 
-        IArbosVersionProvider arbosVersionProviderFactory() =>
-            ArbosState.OpenArbosState(worldState, new SystemBurner(), api.LogManager.GetClassLogger());
-
         ArbitrumChainSpecBasedSpecProvider specProvider = new(
             api.Context.Resolve<ChainSpec>(),
-            arbosVersionProviderFactory,
-            api.LogManager
-        );
+            new ArbosStateVersionProvider(worldState),
+            api.LogManager);
 
         return new ArbitrumTransactionProcessor(
             specProvider,
@@ -76,8 +68,7 @@ public class ArbitrumInitializeBlockchain(ArbitrumNethermindApi api) : Initializ
             virtualMachine,
             api.BlockTree,
             api.LogManager,
-            codeInfoRepository
-        );
+            codeInfoRepository);
     }
 
     protected override BlockProcessor CreateBlockProcessor(BlockCachePreWarmer? preWarmer, ITransactionProcessor transactionProcessor, IWorldState worldState)
@@ -87,12 +78,9 @@ public class ArbitrumInitializeBlockchain(ArbitrumNethermindApi api) : Initializ
         if (api.BlockTree is null) throw new StepDependencyException(nameof(api.BlockTree));
         if (api.ReceiptStorage is null) throw new StepDependencyException(nameof(api.ReceiptStorage));
 
-        IArbosVersionProvider arbosVersionProviderFactory() =>
-            ArbosState.OpenArbosState(worldState, new SystemBurner(), api.LogManager.GetClassLogger());
-
         ArbitrumChainSpecBasedSpecProvider specProvider = new(
             api.Context.Resolve<ChainSpec>(),
-            arbosVersionProviderFactory,
+            new ArbosStateVersionProvider(worldState),
             api.LogManager
         );
 


### PR DESCRIPTION
After #143, right at the start of execution, opening arbos state in `ArbitrumInitializeBlockchain` before passing it to `ArbitrumChainSpecBasedSpecProvider` failed because it is not initialized yet (as `DigestInitMessage` has not been called yet).

Suggested solution is to use lazy initialization, allowing to open arbos in `GetSpec()` instead, which comes after `DigestInitMessage` has been called.