### PR TITLE
fix: Disable EIP-4844 and EIP-4895 for Arbitrum Compatibility

### DIFF
--- a/src/Nethermind.Arbitrum.Test/Config/ArbitrumChainSpecProviderTests.cs
+++ b/src/Nethermind.Arbitrum.Test/Config/ArbitrumChainSpecProviderTests.cs
@@ -69,13 +69,13 @@ public class ArbitrumChainSpecProviderTests
         IReleaseSpec spec2 = specProvider2.GetSpec(new ForkActivation(blockNumber: 100));
 
         // shanghai
-        spec2.IsEip4895Enabled.Should().BeTrue();
+        spec2.IsEip4895Enabled.Should().BeFalse();
         spec2.IsEip3651Enabled.Should().BeTrue();
         spec2.IsEip3855Enabled.Should().BeTrue();
         spec2.IsEip3860Enabled.Should().BeTrue();
 
         // cancun
-        spec2.IsEip4844Enabled.Should().BeTrue();
+        spec2.IsEip4844Enabled.Should().BeFalse();
         spec2.IsEip1153Enabled.Should().BeTrue();
         spec2.IsEip4788Enabled.Should().BeTrue();
         spec2.IsEip5656Enabled.Should().BeTrue();

--- a/src/Nethermind.Arbitrum/Config/ArbitrumChainSpecBasedSpecProvider.cs
+++ b/src/Nethermind.Arbitrum/Config/ArbitrumChainSpecBasedSpecProvider.cs
@@ -19,28 +19,29 @@ public sealed class ArbitrumChainSpecBasedSpecProvider(
     public sealed override IReleaseSpec GetSpec(ForkActivation activation)
     {
         IReleaseSpec spec = base.GetSpec(activation);
-
         ReleaseSpec mutableSpec = (ReleaseSpec)spec;
+        ulong currentArbosVersion = arbosVersionProvider.Get();
 
-        // shanghai
-        mutableSpec.IsEip4895Enabled = arbosVersionProvider.Get() >= ArbosVersion.Eleven;
-        mutableSpec.IsEip3651Enabled = arbosVersionProvider.Get() >= ArbosVersion.Eleven;
-        mutableSpec.IsEip3855Enabled = arbosVersionProvider.Get() >= ArbosVersion.Eleven;
-        mutableSpec.IsEip3860Enabled = arbosVersionProvider.Get() >= ArbosVersion.Eleven;
+        // Shanghai EIPs (ArbOS v11+)
+        bool shanghaiEnabled = currentArbosVersion >= ArbosVersion.Eleven;
+        mutableSpec.IsEip3651Enabled = shanghaiEnabled;
+        mutableSpec.IsEip3855Enabled = shanghaiEnabled;
+        mutableSpec.IsEip3860Enabled = shanghaiEnabled;
 
-        // cancun
-        mutableSpec.IsEip4844Enabled = arbosVersionProvider.Get() >= ArbosVersion.Twenty;
-        mutableSpec.IsEip1153Enabled = arbosVersionProvider.Get() >= ArbosVersion.Twenty;
-        mutableSpec.IsEip4788Enabled = arbosVersionProvider.Get() >= ArbosVersion.Twenty;
-        mutableSpec.IsEip5656Enabled = arbosVersionProvider.Get() >= ArbosVersion.Twenty;
-        mutableSpec.IsEip6780Enabled = arbosVersionProvider.Get() >= ArbosVersion.Twenty;
+        // Cancun EIPs (ArbOS v20+)
+        bool cancunEnabled = currentArbosVersion >= ArbosVersion.Twenty;
+        mutableSpec.IsEip1153Enabled = cancunEnabled;
+        mutableSpec.IsEip4788Enabled = cancunEnabled;
+        mutableSpec.IsEip5656Enabled = cancunEnabled;
+        mutableSpec.IsEip6780Enabled = cancunEnabled;
 
-        // prague
-        mutableSpec.IsEip7702Enabled = arbosVersionProvider.Get() >= ArbosVersion.Forty;
-        mutableSpec.IsEip7251Enabled = arbosVersionProvider.Get() >= ArbosVersion.Forty;
-        mutableSpec.IsEip2537Enabled = arbosVersionProvider.Get() >= ArbosVersion.Forty;
-        mutableSpec.IsEip7002Enabled = arbosVersionProvider.Get() >= ArbosVersion.Forty;
-        mutableSpec.IsEip6110Enabled = arbosVersionProvider.Get() >= ArbosVersion.Forty;
+        // Prague EIPs (ArbOS v40+)
+        bool pragueEnabled = currentArbosVersion >= ArbosVersion.Forty;
+        mutableSpec.IsEip7702Enabled = pragueEnabled;
+        mutableSpec.IsEip7251Enabled = pragueEnabled;
+        mutableSpec.IsEip2537Enabled = pragueEnabled;
+        mutableSpec.IsEip7002Enabled = pragueEnabled;
+        mutableSpec.IsEip6110Enabled = pragueEnabled;
 
         return mutableSpec;
     }


### PR DESCRIPTION
# Fix: Disable EIP-4844 and EIP-4895 for Arbitrum Compatibility

## Problem
Block hash mismatch between Nethermind-Arbitrum and Nitro:
```
blob gas used: expected , got 0
```

## Root Cause
- **EIP-4844**: Nethermind calculated `BlobGasUsed = 0`, Nitro expects `null`
- **EIP-4895**: Conflicting withdrawal mechanisms

## Solution
Disable EIP-4844 and EIP-4895

### EIP-4844 Not Supported
**Nitro Code:** `go-ethereum/consensus/misc/eip4844/eip4844.go`
```go
// CalcBlobFee calculates the blobfee from the header's excess blob gas field.
func CalcBlobFee(config *params.ChainConfig, header *types.Header) *big.Int {
	if config.IsArbitrum() {
		// Arbitrum does not support blob transactions, so we return 0.
		return big.NewInt(0)
	}
	var frac uint64
	switch config.LatestFork(header.Time, types.DeserializeHeaderExtraInformation(header).ArbOSFormatVersion) {
	case forks.Osaka:
		frac = config.BlobScheduleConfig.Osaka.UpdateFraction
	case forks.Prague:
		frac = config.BlobScheduleConfig.Prague.UpdateFraction
	case forks.Cancun:
		frac = config.BlobScheduleConfig.Cancun.UpdateFraction
	default:
		panic("calculating blob fee on unsupported fork")
	}
	return fakeExponential(minBlobGasPrice, new(big.Int).SetUint64(*header.ExcessBlobGas), new(big.Int).SetUint64(frac))
}

// MaxBlobsPerBlock returns the max blobs per block for a block at the given timestamp.
func MaxBlobsPerBlock(cfg *params.ChainConfig, time uint64) int {
	if cfg.BlobScheduleConfig == nil {
		return 0
	}
	var (
		london = cfg.LondonBlock
		s      = cfg.BlobScheduleConfig
	)
	switch {
	case cfg.IsOsaka(london, time) && s.Osaka != nil:
		return s.Osaka.Max
	// we can use 0 here because arbitrum doesn't support Blob transactions.
	case cfg.IsPrague(london, time, 0) && s.Prague != nil:
		return s.Prague.Max
	// we can use 0 here because arbitrum doesn't support Blob transactions.
	case cfg.IsCancun(london, time, 0) && s.Cancun != nil:
		return s.Cancun.Max
	default:
		return 0
	}
}

// targetBlobsPerBlock returns the target number of blobs in a block at the given timestamp.
func targetBlobsPerBlock(cfg *params.ChainConfig, time uint64) int {
	if cfg.BlobScheduleConfig == nil {
		return 0
	}
	var (
		london = cfg.LondonBlock
		s      = cfg.BlobScheduleConfig
	)
	switch {
	case cfg.IsOsaka(london, time) && s.Osaka != nil:
		return s.Osaka.Target
	// we can use 0 here because arbitrum doesn't support Blob transactions.
	case cfg.IsPrague(london, time, 0) && s.Prague != nil:
		return s.Prague.Target
	// we can use 0 here because arbitrum doesn't support Blob transactions.
	case cfg.IsCancun(london, time, 0) && s.Cancun != nil:
		return s.Cancun.Target
	default:
		return 0
	}
}
```

### EIP-4895 Conflicts with Arbitrum Architecture
Nitro uses ArbSys (0x64) for L1-L2 messaging instead of EIP-4895
