### PR TITLE
Remove unused package source, specify source mapping required by centralized package management

### DIFF
--- a/src/nuget.config
+++ b/src/nuget.config
@@ -3,6 +3,10 @@
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="dotnet-libraries" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
   </packageSources>
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
 </configuration>


### PR DESCRIPTION
`dotnet-libraries` is not used anymore in Nethermind - https://github.com/NethermindEth/nethermind/blob/master/nuget.config
`packageSourceMapping` must be specified when centralized package management is enabled to avoid [NU1507](https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu1507)
