### PR TITLE
Set fixed addresses when decoding internal transactions

### DIFF
--- a/src/Nethermind.Arbitrum/Execution/Transactions/ArbitrumTransaction.cs
+++ b/src/Nethermind.Arbitrum/Execution/Transactions/ArbitrumTransaction.cs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
+using Nethermind.Arbitrum.Arbos;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Int256;
@@ -17,6 +17,10 @@ namespace Nethermind.Arbitrum.Execution.Transactions
         public ArbitrumInternalTransaction()
         {
             Type = (TxType)ArbitrumTxType.ArbitrumInternal;
+            //in nitro this is always the arbos address
+            To = ArbosAddresses.ArbosAddress;
+            //in nitro this is always the arbos address via NewArbitrumSigner
+            SenderAddress = ArbosAddresses.ArbosAddress;
         }
     }
 

--- a/src/Nethermind.Arbitrum/Execution/Transactions/ArbitrumTxDecoder.cs
+++ b/src/Nethermind.Arbitrum/Execution/Transactions/ArbitrumTxDecoder.cs
@@ -41,17 +41,11 @@ namespace Nethermind.Arbitrum.Execution.Transactions
         {
             transaction.ChainId = rlpStream.DecodeULong();
             transaction.Data = rlpStream.DecodeByteArray();
-            //set hardcoded sender and to addresses to avoid issues with blocks decoded from DB
-            transaction.SenderAddress = ArbosAddresses.ArbosAddress;
-            transaction.To = ArbosAddresses.ArbosAddress;
         }
         protected override void DecodePayload(Transaction transaction, ref Rlp.ValueDecoderContext decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
         {
             transaction.ChainId = decoderContext.DecodeULong();
             transaction.Data = decoderContext.DecodeByteArray();
-            //set hardcoded sender and to addresses to avoid issues with blocks decoded from DB
-            transaction.SenderAddress = ArbosAddresses.ArbosAddress;
-            transaction.To = ArbosAddresses.ArbosAddress;
         }
     }
 


### PR DESCRIPTION
Fixes: #216 
Sets fixed addresses when decoding internal transactions. When a block is decoded form memory stream, internal arbitrum transactions do not decode fixed addresses - hardcoded to Arbos address. This causes failure when recovering `Sender` from signature (transactions are unsigned).
The same scenario happens when processing blocks from DB after graceful shutdown.