### PR TITLE
fix: Use correct ip for RPC

### DIFF
--- a/src/Nethermind.Arbitrum/Properties/configs/arbitrum-local.json
+++ b/src/Nethermind.Arbitrum/Properties/configs/arbitrum-local.json
@@ -25,7 +25,7 @@
     "EnginePort": 20551,
     "UnsecureDevNoRpcAuthentication": true,
     "AdditionalRpcUrls": [
-      "http://localhost:28551|http;ws|net;eth;subscribe;web3;client;debug"
+      "http://0.0.0.0:28551|http;ws|net;eth;subscribe;web3;client;debug"
     ],
     "EnabledModules": [
       "Admin",

--- a/src/Nethermind.Arbitrum/Properties/configs/arbitrum-sepolia-archive.json
+++ b/src/Nethermind.Arbitrum/Properties/configs/arbitrum-sepolia-archive.json
@@ -17,7 +17,7 @@
     "EnginePort": 20551,
     "UnsecureDevNoRpcAuthentication": true,
     "AdditionalRpcUrls": [
-      "http://localhost:28551|http;ws|net;eth;subscribe;web3;client;debug"
+      "http://0.0.0.0:28551|http;ws|net;eth;subscribe;web3;client;debug"
     ],
     "EnabledModules": [
       "Admin",

--- a/src/Nethermind.Arbitrum/Properties/configs/arbitrum-sepolia.json
+++ b/src/Nethermind.Arbitrum/Properties/configs/arbitrum-sepolia.json
@@ -25,7 +25,7 @@
     "EnginePort": 20551,
     "UnsecureDevNoRpcAuthentication": true,
     "AdditionalRpcUrls": [
-      "http://localhost:28551|http;ws|net;eth;subscribe;web3;client;debug"
+      "http://0.0.0.0:28551|http;ws|net;eth;subscribe;web3;client;debug"
     ],
     "EnabledModules": [
       "Admin",


### PR DESCRIPTION
Using localhost makes the RPC available
only from the same machine (or container).

In this case, when running on k8s,
the health checks will fail because
the pod won't be accepting requests
to the 28551 port