### PR TITLE
Enable non blocking memory pruning for sepolia archive

### DIFF
--- a/src/Nethermind.Arbitrum/Properties/configs/arbitrum-sepolia-archive.json
+++ b/src/Nethermind.Arbitrum/Properties/configs/arbitrum-sepolia-archive.json
@@ -44,9 +44,9 @@
   },
   "Pruning": {
     "Mode": "None",
-    "MaxUnpersistedBlockCount": 4800,
+    "MaxUnpersistedBlockCount": 2500,
     "MinUnpersistedBlockCount": 72,
-    "MaxBufferedCommitCount": 0
+    "MaxBufferedCommitCount": 2500
   },
   "Blocks": {
     "PreWarmStateOnBlockProcessing": false


### PR DESCRIPTION
Enable non blocking memory pruning for sepolia archive - to be merge when this [fix](https://github.com/NethermindEth/nethermind/pull/9346) is available