### PR TITLE
EVM call depth and grand caller assignment

### DIFF
--- a/src/Nethermind.Arbitrum.Test/Precompiles/ArbSysTests.cs
+++ b/src/Nethermind.Arbitrum.Test/Precompiles/ArbSysTests.cs
@@ -206,7 +206,7 @@ public class ArbSysTests
         _ = ArbOSInitialization.Create(worldState);
         ArbitrumPrecompileExecutionContext context = new PrecompileTestContextBuilder(worldState, 1_000_000)
             .WithArbosState()
-            .WithCallDepth(2);
+            .WithCallDepth(1);
 
         bool result = ArbSys.IsTopLevelCall(context);
 
@@ -222,7 +222,7 @@ public class ArbSysTests
         _ = ArbOSInitialization.Create(worldState);
         ArbitrumPrecompileExecutionContext context = new PrecompileTestContextBuilder(worldState, 1_000_000)
             .WithArbosState()
-            .WithCallDepth(3);
+            .WithCallDepth(2);
 
         bool result = ArbSys.IsTopLevelCall(context);
 
@@ -239,7 +239,7 @@ public class ArbSysTests
         _ = ArbOSInitialization.Create(worldState);
         ArbitrumPrecompileExecutionContext context = new PrecompileTestContextBuilder(worldState, 1_000_000)
             .WithArbosState()
-            .WithCallDepth(5) // Deep call, but should still be top level due to origin == grandCaller
+            .WithCallDepth(4) // Deep call, but should still be top level due to origin == grandCaller
             .WithOrigin(commonAddress.ToHash())
             .WithGrandCaller(commonAddress)
             .WithArbosVersion(ArbosVersion.Six)
@@ -271,8 +271,8 @@ public class ArbSysTests
         _ = ArbOSInitialization.Create(worldState);
         ArbitrumPrecompileExecutionContext context = new PrecompileTestContextBuilder(worldState, 1_000_000)
             .WithArbosState()
-            .WithCallDepth(2) // Top level in ArbOS <    6 requires CallDepth == 2
-            .WithGrandCaller(TestItem.AddressB) // Need valid GrandCaller for CallDepth = 2
+            .WithCallDepth(1) // Top level in ArbOS <    6 requires Nitro CallDepth == 2, which corresponds Nethermind CallDepth == 1
+            .WithGrandCaller(TestItem.AddressB) // Need valid GrandCaller for CallDepth = 1
             .WithTopLevelTxType(ArbitrumTxType.ArbitrumUnsigned)
             .WithArbosVersion(ArbosVersion.Five);
 
@@ -290,7 +290,7 @@ public class ArbSysTests
         _ = ArbOSInitialization.Create(worldState);
         ArbitrumPrecompileExecutionContext context = new PrecompileTestContextBuilder(worldState, 1_000_000)
             .WithArbosState()
-            .WithCallDepth(3)
+            .WithCallDepth(2)
             .WithTopLevelTxType(ArbitrumTxType.ArbitrumUnsigned)
             .WithArbosVersion(ArbosVersion.Five);
 
@@ -308,7 +308,7 @@ public class ArbSysTests
         _ = ArbOSInitialization.Create(worldState);
         ArbitrumPrecompileExecutionContext context = new PrecompileTestContextBuilder(worldState, 1_000_000)
             .WithArbosState()
-            .WithCallDepth(2) // Top level in ArbOS < 6 requires CallDepth == 2
+            .WithCallDepth(1) // Top level in ArbOS < 6 requires Nitro CallDepth == 2, which corresponds to Nethermind CallDepth == 1
             .WithTopLevelTxType(ArbitrumTxType.ArbitrumLegacy)
             .WithArbosVersion(ArbosVersion.Five);
 
@@ -329,7 +329,7 @@ public class ArbSysTests
         _ = ArbOSInitialization.Create(worldState);
         ArbitrumPrecompileExecutionContext context = new PrecompileTestContextBuilder(worldState, 1_000_000)
             .WithArbosState()
-            .WithCallDepth(2) // Need CallDepth > 1 to use GrandCaller, and == 2 for IsTopLevel in ArbOS < 6
+            .WithCallDepth(1) // Need CallDepth > 1 to use GrandCaller, and == 2 for IsTopLevel in ArbOS < 6 for Nitro, in Nethermind we need - 1
             .WithGrandCaller(aliasedAddress)
             .WithOrigin(TestItem.AddressA.ToHash()) // Ensure Origin is set
             .WithTopLevelTxType(ArbitrumTxType.ArbitrumUnsigned)
@@ -349,7 +349,7 @@ public class ArbSysTests
         _ = ArbOSInitialization.Create(worldState);
         ArbitrumPrecompileExecutionContext context = new PrecompileTestContextBuilder(worldState, 1_000_000)
             .WithArbosState()
-            .WithCallDepth(1)
+            .WithCallDepth(0)
             .WithTopLevelTxType(ArbitrumTxType.ArbitrumLegacy);
 
         Address result = ArbSys.MyCallersAddressWithoutAliasing(context);
@@ -656,14 +656,14 @@ public class ArbSysTests
     {
         // Test that IsTopLevel behaves differently for ArbOS versions < 6 and >= 6
 
-        // ArbOS < 6: top level when callDepth == 2
+        // ArbOS < 6: top level when callDepth == 1 (was 2 in Nitro)
         IWorldState worldState = TestWorldStateFactory.CreateForTest();
         using var worldStateDisposer = worldState.BeginScope(IWorldState.PreGenesis);
 
         _ = ArbOSInitialization.Create(worldState);
         ArbitrumPrecompileExecutionContext contextV5 = new PrecompileTestContextBuilder(worldState, 1_000_000)
             .WithArbosState()
-            .WithCallDepth(2)
+            .WithCallDepth(1)
             .WithGrandCaller(TestItem.AddressB) // Need valid GrandCaller for CallDepth = 2
             .WithTopLevelTxType(ArbitrumTxType.ArbitrumUnsigned)
             .WithArbosVersion(ArbosVersion.Five);
@@ -671,10 +671,10 @@ public class ArbSysTests
         bool resultV5 = ArbSys.WasMyCallersAddressAliased(contextV5);
         resultV5.Should().BeTrue();
 
-        // ArbOS >= 6: top level when callDepth < 2
+        // ArbOS >= 6: top level when callDepth < 2 in Nitro, in Nethermind it should be == 0
         ArbitrumPrecompileExecutionContext contextV6CallDepth = new PrecompileTestContextBuilder(worldState, 1_000_000)
             .WithArbosState()
-            .WithCallDepth(1)
+            .WithCallDepth(0)
             .WithTopLevelTxType(ArbitrumTxType.ArbitrumUnsigned)
             .WithArbosVersion(ArbosVersion.Six);
 
@@ -685,7 +685,7 @@ public class ArbSysTests
         Address commonAddress = TestItem.AddressC;
         ArbitrumPrecompileExecutionContext contextV6Origin = new PrecompileTestContextBuilder(worldState, 1_000_000)
             .WithArbosState()
-            .WithCallDepth(3) // Deep call
+            .WithCallDepth(2) // Deep call
             .WithOrigin(commonAddress.ToHash())
             .WithGrandCaller(commonAddress)
             .WithTopLevelTxType(ArbitrumTxType.ArbitrumUnsigned)
@@ -722,8 +722,8 @@ public class ArbSysTests
             _ = ArbOSInitialization.Create(worldState);
             ArbitrumPrecompileExecutionContext context = new PrecompileTestContextBuilder(worldState, 1_000_000)
                 .WithArbosState()
-                .WithCallDepth(2) // For ArbOS < 6, IsTopLevel requires CallDepth == 2
-                .WithGrandCaller(TestItem.AddressB) // Need valid GrandCaller for CallDepth = 2
+                .WithCallDepth(1) // For ArbOS < 6, IsTopLevel requires CallDepth == 2 in Nitro, in Nethermind it should be == 1
+                .WithGrandCaller(TestItem.AddressB) // Need valid GrandCaller for CallDepth = 2 in Nitro, in Nethermind it should be == 1
                 .WithTopLevelTxType(txType)
                 .WithArbosVersion(ArbosVersion.Five);
 
@@ -739,7 +739,7 @@ public class ArbSysTests
             _ = ArbOSInitialization.Create(worldState);
             ArbitrumPrecompileExecutionContext context = new PrecompileTestContextBuilder(worldState, 1_000_000)
                 .WithArbosState()
-                .WithCallDepth(1)
+                .WithCallDepth(0)
                 .WithTopLevelTxType(txType)
                 .WithArbosVersion(ArbosVersion.Five);
 
@@ -789,7 +789,7 @@ public class ArbSysTests
         _ = ArbOSInitialization.Create(worldState);
         ArbitrumPrecompileExecutionContext context = new PrecompileTestContextBuilder(worldState, 1_000_000)
             .WithArbosState()
-            .WithCallDepth(2) // Top level for ArbOS < 6
+            .WithCallDepth(1) // Top level for ArbOS < 6
             .WithGrandCaller(Address.Zero) // GrandCaller is Address.Zero
             .WithTopLevelTxType(ArbitrumTxType.ArbitrumUnsigned) // Aliasing tx type
             .WithArbosVersion(ArbosVersion.Five);

--- a/src/Nethermind.Arbitrum.Test/Precompiles/Parser/ArbSysParserTests.cs
+++ b/src/Nethermind.Arbitrum.Test/Precompiles/Parser/ArbSysParserTests.cs
@@ -174,7 +174,7 @@ public class ArbSysParserTests
 
     [TestCase(0, true)]
     [TestCase(1, true)]
-    [TestCase(2, true)]
+    [TestCase(2, false)]
     [TestCase(3, false)]
     [TestCase(10, false)]
     public void IsTopLevelCall_WhenDifferentCallDepths_ReturnsCorrectSerialization(int callDepth, bool expectedResult)
@@ -262,10 +262,10 @@ public class ArbSysParserTests
         PrecompileTestContextBuilder context = new(worldState, GasSupplied: ulong.MaxValue)
         {
             TopLevelTxType = ArbitrumTxType.ArbitrumUnsigned,
-            CallDepth = 1
+            CallDepth = 0
         };
         context.WithArbosState();
-        // Ensure we're at top level (CallDepth should be 0 or 1 for IsTopLevel to return true)
+        // Ensure we're at top level (CallDepth should be 0 for IsTopLevel to return true in ArbOS >= 6)
 
         bool exists = ArbSysParser.PrecompileImplementation.TryGetValue(_wasMyCallersAddressAliasedId, out PrecompileHandler? implementation);
         exists.Should().BeTrue();

--- a/src/Nethermind.Arbitrum/Core/ArbitrumBlockHeader.cs
+++ b/src/Nethermind.Arbitrum/Core/ArbitrumBlockHeader.cs
@@ -41,7 +41,6 @@ public class ArbitrumBlockHeader : BlockHeader
         AuRaStep = original.AuRaStep;
         BaseFeePerGas = original.BaseFeePerGas;
         WithdrawalsRoot = original.WithdrawalsRoot;
-        SealEngineType = original.SealEngineType;
         IsPostMerge = original.IsPostMerge;
     }
 }

--- a/src/Nethermind.Arbitrum/Evm/ArbitrumVirtualMachine.cs
+++ b/src/Nethermind.Arbitrum/Evm/ArbitrumVirtualMachine.cs
@@ -401,8 +401,8 @@ public sealed unsafe class ArbitrumVirtualMachine(
             state.Env
         );
 
-        // I think state.Env.CallDepth == StateStack.Count (invariant)
-        Address? grandCaller = state.Env.CallDepth >= 2 ? StateStack.ElementAt(state.Env.CallDepth - 2).From : null;
+        // Geth EVM has depth started from 1, Nethermind has depth starting from 0
+        Address? grandCaller = state.Env.CallDepth > 0 ? StateStack.ElementAt(state.Env.CallDepth - 1).From : null;
 
         ArbitrumPrecompileExecutionContext context = new(
             state.Env.Caller, state.Env.Value, GasSupplied: (ulong)state.GasAvailable,

--- a/src/Nethermind.Arbitrum/Precompiles/ArbSys.cs
+++ b/src/Nethermind.Arbitrum/Precompiles/ArbSys.cs
@@ -115,7 +115,7 @@ public static class ArbSys
     public static UInt256 GetStorageGasAvailable() => 0;
 
     // IsTopLevelCall checks if the call is top-level (deprecated)
-    public static bool IsTopLevelCall(ArbitrumPrecompileExecutionContext context) => context.CallDepth <= 2;
+    public static bool IsTopLevelCall(ArbitrumPrecompileExecutionContext context) => context.CallDepth <= 1;
 
     // MapL1SenderContractAddressToL2Alias gets the contract's L2 alias
     public static Address MapL1SenderContractAddressToL2Alias(Address sender) => RemapL1Address(sender);
@@ -124,7 +124,7 @@ public static class ArbSys
     public static bool WasMyCallersAddressAliased(ArbitrumPrecompileExecutionContext context)
     {
         bool topLevel = context.ArbosState.CurrentArbosVersion < ArbosVersion.Six
-            ? context.CallDepth == 2 : IsTopLevel(context);
+            ? context.CallDepth == 1 : IsTopLevel(context);
 
         return topLevel && DoesTxAlias(context.TopLevelTxType);
     }
@@ -132,7 +132,7 @@ public static class ArbSys
     // MyCallersAddressWithoutAliasing gets the caller's caller without any potential aliasing
     public static Address MyCallersAddressWithoutAliasing(ArbitrumPrecompileExecutionContext context)
     {
-        Address address = context.CallDepth > 1 ? context.GrandCaller! : Address.Zero;
+        Address address = context.GrandCaller ?? Address.Zero;
 
         if (WasMyCallersAddressAliased(context))
             address = InverseRemapL1Address(address);
@@ -357,5 +357,5 @@ public static class ArbSys
             or ArbitrumTxType.ArbitrumRetry;
 
     private static bool IsTopLevel(ArbitrumPrecompileExecutionContext context)
-        => context.CallDepth < 2 || context.Origin == context.GrandCaller?.ToHash();
+        => context.CallDepth == 0 || context.Origin == context.GrandCaller?.ToHash();
 }


### PR DESCRIPTION
Fixes Closes https://github.com/NethermindEth/nethermind-arbitrum/issues/287

These changes align with Nethermind's call depth convention (starting from 0) instead of Geth's/Nitro's (starting from 1).

Note: `ArbitrumBlockHeader.cs` change is NC sync.