### PR TITLE
fix: ArbFunctionTable throws failure instead of revert exception

### DIFF
--- a/src/Nethermind.Arbitrum.Test/Precompiles/ArbFunctionTableTests.cs
+++ b/src/Nethermind.Arbitrum.Test/Precompiles/ArbFunctionTableTests.cs
@@ -65,7 +65,8 @@ public sealed class ArbFunctionTableTests
         Action action = () => ArbFunctionTable.Get(_context, addr, index);
 
         ArbitrumPrecompileException exception = action.Should().Throw<ArbitrumPrecompileException>().Which;
-        exception.Message.Should().Contain("table is empty");
+        ArbitrumPrecompileException expected = ArbitrumPrecompileException.CreateFailureException("table is empty");
+        exception.Should().BeEquivalentTo(expected, o => o.ForArbitrumPrecompileException());
     }
 
     [Test]

--- a/src/Nethermind.Arbitrum.Test/Precompiles/Parser/ArbFunctionTableParserTests.cs
+++ b/src/Nethermind.Arbitrum.Test/Precompiles/Parser/ArbFunctionTableParserTests.cs
@@ -140,7 +140,8 @@ public sealed class ArbFunctionTableParserTests
         Action action = () => handler!(_context, calldata);
 
         ArbitrumPrecompileException exception = action.Should().Throw<ArbitrumPrecompileException>().Which;
-        exception.Message.Should().Contain("table is empty");
+        ArbitrumPrecompileException expected = ArbitrumPrecompileException.CreateFailureException("table is empty");
+        exception.Should().BeEquivalentTo(expected, o => o.ForArbitrumPrecompileException());
     }
 
     [Test]

--- a/src/Nethermind.Arbitrum/Precompiles/ArbFunctionTable.cs
+++ b/src/Nethermind.Arbitrum/Precompiles/ArbFunctionTable.cs
@@ -38,10 +38,10 @@ public static class ArbFunctionTable
     }
 
     /// <summary>
-    /// Get reverts since the table is empty
+    /// Get fails since the table is empty
     /// </summary>
     public static (UInt256, bool, UInt256) Get(ArbitrumPrecompileExecutionContext context, Address addr, UInt256 index)
     {
-        throw ArbitrumPrecompileException.CreateRevertException("table is empty");
+        throw ArbitrumPrecompileException.CreateFailureException("table is empty");
     }
 }


### PR DESCRIPTION
Revert != failure

Here are the 2 categories of errors that nitro distinguishes during precompile execution:
1. revert
   1.1. when returning `vm.ErrExecutionReverted`
   1.2 solidity errors, which are fields in the precompile struct
2. failure:
   2.1 any other error (`programs.ErrProgramActivation` is a sub-error)

In the end, the vm decides, see nitro check:
```go
if arbosVersion >= params.ArbosVersion_11 || errRet == vm.ErrExecutionReverted {
	return nil, callerCtx.gasLeft, vm.ErrExecutionReverted
}
```
So, if arbos version is >= 11, the error returned is considered a revert, whatever the original error.