### PR TITLE
fix: Differentiate read only and static calls for precompile execution

### DIFF
--- a/src/Nethermind.Arbitrum.Test/Infrastructure/PrecompileTestContextBuilder.cs
+++ b/src/Nethermind.Arbitrum.Test/Infrastructure/PrecompileTestContextBuilder.cs
@@ -14,7 +14,7 @@ using Nethermind.Specs.Forks;
 namespace Nethermind.Arbitrum.Test.Infrastructure;
 
 public record PrecompileTestContextBuilder(IWorldState WorldState, ulong GasSupplied)
-    : ArbitrumPrecompileExecutionContext(Address.Zero, UInt256.Zero, GasSupplied, false, WorldState, new BlockExecutionContext(), 0, null)
+    : ArbitrumPrecompileExecutionContext(Address.Zero, UInt256.Zero, GasSupplied, WorldState, new BlockExecutionContext(), 0, null)
 {
     public PrecompileTestContextBuilder WithArbosState()
     {

--- a/src/Nethermind.Arbitrum.Test/Precompiles/Parser/ArbDebugParserTests.cs
+++ b/src/Nethermind.Arbitrum.Test/Precompiles/Parser/ArbDebugParserTests.cs
@@ -104,9 +104,10 @@ public class ArbDebugParserTests
     [Test]
     public void EventsView_Always_ThrowsAsViewFunction()
     {
-        ArbitrumPrecompileExecutionContext context = new(Address.Zero, UInt256.Zero, DefaultGasSupplied, ReadOnly: true, _worldState, new BlockExecutionContext(), 0, null)
+        ArbitrumPrecompileExecutionContext context = new(Address.Zero, UInt256.Zero, DefaultGasSupplied, _worldState, new BlockExecutionContext(), 0, null)
         {
-            ArbosState = _freeArbosState
+            ArbosState = _freeArbosState,
+            ReadOnly = true,
         };
 
         bool exists = ArbDebugParser.PrecompileImplementation.TryGetValue(_eventsViewId, out PrecompileHandler? eventsView);

--- a/src/Nethermind.Arbitrum/Evm/ArbitrumVirtualMachine.cs
+++ b/src/Nethermind.Arbitrum/Evm/ArbitrumVirtualMachine.cs
@@ -407,11 +407,12 @@ public sealed unsafe class ArbitrumVirtualMachine(
         Address? grandCaller = state.Env.CallDepth > 0 ? StateStack.ElementAt(state.Env.CallDepth - 1).From : null;
 
         ArbitrumPrecompileExecutionContext context = new(
-            state.Env.Caller, state.Env.Value, GasSupplied: (ulong)state.GasAvailable,
-            ReadOnly: state.IsStatic, WorldState, BlockExecutionContext,
-            ChainId.ToByteArray().ToULongFromBigEndianByteArrayWithoutLeadingZeros(), tracingInfo, Spec
+            state.Env.Caller, state.Env.Value, GasSupplied: (ulong)state.GasAvailable, WorldState,
+            BlockExecutionContext, ChainId.ToByteArray().ToULongFromBigEndianByteArrayWithoutLeadingZeros(),
+            tracingInfo, Spec
         )
         {
+            IsCallStatic = state.IsStatic,
             BlockHashProvider = BlockHashProvider,
             CallDepth = state.Env.CallDepth,
             GrandCaller = grandCaller,
@@ -481,7 +482,7 @@ public sealed unsafe class ArbitrumVirtualMachine(
         if (!result.PrecompileSuccess!.Value)
             return result;
 
-        if (!context.ReadOnly || context.ArbosState.CurrentArbosVersion < ArbosVersion.Eleven)
+        if (!context.IsCallStatic || context.ArbosState.CurrentArbosVersion < ArbosVersion.Eleven)
             OwnerLogic.EmitOwnerSuccessEvent(state, context, precompile);
 
         return result;

--- a/src/Nethermind.Arbitrum/Execution/ArbitrumTransactionProcessor.cs
+++ b/src/Nethermind.Arbitrum/Execution/ArbitrumTransactionProcessor.cs
@@ -551,7 +551,7 @@ namespace Nethermind.Arbitrum.Execution
 
             ulong ticketCreatedGasCost = ArbRetryableTx.TicketCreatedEventGasCost(tx.Hash);
             ArbitrumPrecompileExecutionContext precompileExecutionContext = new(Address.Zero, tx.Value,
-                ticketCreatedGasCost, false, worldState, blCtx, tx.ChainId ?? 0, _tracingInfo, _currentSpec!);
+                ticketCreatedGasCost, worldState, blCtx, tx.ChainId ?? 0, _tracingInfo, _currentSpec!);
 
             ArbRetryableTx.EmitTicketCreatedEvent(precompileExecutionContext, tx.Hash);
             eventLogs.AddRange(precompileExecutionContext.EventLogs);
@@ -652,7 +652,7 @@ namespace Nethermind.Arbitrum.Execution
             ulong redeemScheduledGasCost = ArbRetryableTx.RedeemScheduledEventGasCost(tx.Hash, outerRetryTx.Hash,
                 (ulong)outerRetryTx.Nonce, userGas, tx.FeeRefundAddr!, availableRefund, submissionFee);
             precompileExecutionContext = new(Address.Zero, tx.Value,
-                redeemScheduledGasCost, false, worldState, blCtx, tx.ChainId ?? 0, _tracingInfo, _currentSpec!);
+                redeemScheduledGasCost, worldState, blCtx, tx.ChainId ?? 0, _tracingInfo, _currentSpec!);
 
             ArbRetryableTx.EmitRedeemScheduledEvent(precompileExecutionContext, tx.Hash, outerRetryTx.Hash,
                 (ulong)outerRetryTx.Nonce, userGas, tx.FeeRefundAddr!, availableRefund, submissionFee);

--- a/src/Nethermind.Arbitrum/Precompiles/ArbitrumPrecompileExecutionContext.cs
+++ b/src/Nethermind.Arbitrum/Precompiles/ArbitrumPrecompileExecutionContext.cs
@@ -15,7 +15,6 @@ public record ArbitrumPrecompileExecutionContext(
     Address Caller,
     UInt256 Value,
     ulong GasSupplied,
-    bool ReadOnly,
     IWorldState WorldState,
     BlockExecutionContext BlockExecutionContext,
     ulong ChainId,
@@ -23,7 +22,9 @@ public record ArbitrumPrecompileExecutionContext(
     IReleaseSpec ReleaseSpec = null!
 ) : IBurner
 {
-    private ulong _gasLeft = GasSupplied;
+    public bool ReadOnly { get; set; }
+
+    public bool IsCallStatic { get; init; }
 
     public TracingInfo? TracingInfo { get; protected set; } = TracingInfo;
 
@@ -64,6 +65,8 @@ public record ArbitrumPrecompileExecutionContext(
     public bool IsMethodCalledPure { get; set; }
 
     public ulong Burned => GasSupplied - GasLeft;
+
+    private ulong _gasLeft = GasSupplied;
 
     public void Burn(ulong amount)
     {

--- a/src/Nethermind.Arbitrum/Precompiles/PrecompileHelper.cs
+++ b/src/Nethermind.Arbitrum/Precompiles/PrecompileHelper.cs
@@ -80,7 +80,7 @@ public static class PrecompileHelper
             return false;
 
         // Tried to write to global state in read-only mode
-        if (abiFunction.AbiFunctionDescription.StateMutability >= StateMutability.NonPayable && context.ReadOnly)
+        if (abiFunction.AbiFunctionDescription.StateMutability >= StateMutability.NonPayable && context.IsCallStatic)
             return false;
 
         // Tried to pay something that's non-payable
@@ -88,6 +88,7 @@ public static class PrecompileHelper
             return false;
 
         context.IsMethodCalledPure = abiFunction.AbiFunctionDescription.StateMutability == StateMutability.Pure;
+        context.ReadOnly = abiFunction.AbiFunctionDescription.StateMutability <= StateMutability.View;
 
         return true;
     }


### PR DESCRIPTION
In nitro:
- `readOnly` passed to `Precompile.Call` [here](https://github.com/NethermindEth/arbitrum-nitro/blob/master/precompiles/precompile.go#L691) indicates whether call is static
- `readOnly` passed to the precompile context [here](https://github.com/NethermindEth/arbitrum-nitro/blob/master/precompiles/precompile.go#L732) indicates whether method is pure/view

We used to not make the difference between the 2, so, here is the fix