### PR TITLE
fix: use `ExecuteTransactionProcessorAdapter` for proper intra-block state visibility

### DIFF
--- a/src/Nethermind.Arbitrum/Execution/ArbitrumBlockProcessor.cs
+++ b/src/Nethermind.Arbitrum/Execution/ArbitrumBlockProcessor.cs
@@ -100,7 +100,7 @@ namespace Nethermind.Arbitrum.Execution
             BlockValidationTransactionsExecutor.ITransactionProcessedEventHandler? transactionProcessedHandler = null)
             : IBlockProductionTransactionsExecutor
         {
-            private readonly ITransactionProcessorAdapter _transactionProcessor = new BuildUpTransactionProcessorAdapter(txProcessor);
+            private readonly ITransactionProcessorAdapter _transactionProcessor = new ExecuteTransactionProcessorAdapter(txProcessor);
             private readonly ILogger _logger = logManager.GetClassLogger();
             private BlockValidationTransactionsExecutor.ITransactionProcessedEventHandler? _transactionProcessedHandler = transactionProcessedHandler;
 


### PR DESCRIPTION
Fixes hash mismatch on block №7

`BuildUpTransactionProcessorAdapter` uses `ExecutionOptions.None` which skips commits between transactions. This breaks Arbitrum's intra-block dependencies where ArbOS storage changes from TX1 must be visible to TX2.
