### PR TITLE
Remove redundant ResetPages, add comment why we can skip journaling for WASM store

### DIFF
--- a/src/Nethermind.Arbitrum/Execution/ArbitrumBlockProcessor.cs
+++ b/src/Nethermind.Arbitrum/Execution/ArbitrumBlockProcessor.cs
@@ -149,8 +149,6 @@ namespace Nethermind.Arbitrum.Execution
                     if (currentTx is null)
                         break;
 
-                    wasmStore.ResetPages();
-
                     TxAction action = ProcessTransaction(block, currentTx, processedCount++, receiptsTracer,
                         processingOptions, consideredTx, arbosState, blockGasLeft, userTxsProcessed);
                     if (action == TxAction.Stop)

--- a/src/Nethermind.Arbitrum/Stylus/WasmStore.cs
+++ b/src/Nethermind.Arbitrum/Stylus/WasmStore.cs
@@ -7,6 +7,29 @@ using Nethermind.Core.Crypto;
 
 namespace Nethermind.Arbitrum.Stylus;
 
+/// <summary>
+/// Stores compiled Stylus ASM binaries keyed by module hash.
+///
+/// Unlike Nitro's implementation, this store does not use journaling for ASM entries.
+/// This is safe because:
+///
+/// 1. VISIBILITY CONTROL: Program activation status (Program.Version) is stored in ArbOS
+///    state storage, which participates in WorldState snapshots and reverts automatically.
+///    A program cannot be executed unless Program.Version > 0, regardless of whether
+///    its ASM exists in this store.
+///
+/// 2. GAS CALCULATION: Gas costs are determined by Program.cached flag in ArbOS state
+///    and the block-local RecentWasms cache - both deterministic across all nodes.
+///    The actual presence of ASM in this store or native cache does not affect gas.
+///
+/// 3. EXECUTION CORRECTNESS: ASM is always provided to the WASM runtime during calls.
+///    Cache hits improve performance but produce identical execution results as cache misses.
+///
+/// Consequence of no journaling: If a transaction activates a program and then reverts
+/// (including nested call reverts), the ASM bytes may remain in this store as "garbage" -
+/// orphaned entries with no valid Program.Version pointing to them. This is acceptable
+/// for now because these entries are invisible to execution and do not affect consensus.
+/// </summary>
 public class WasmStore : IWasmStore
 {
     private static IWasmStore _store = null!;


### PR DESCRIPTION
`ResetPages` is being called in `ArbitrumVirtualMachine.ExecuteTransaction`. We don't need both.