### PR TITLE
MaxInitCodeSize & MaxCodeSize (EIP-3860, EIP-170) fixes

### DIFF
--- a/src/Nethermind.Arbitrum/Config/ArbitrumDynamicSpecProvider.cs
+++ b/src/Nethermind.Arbitrum/Config/ArbitrumDynamicSpecProvider.cs
@@ -40,6 +40,9 @@ public sealed class ArbitrumDynamicSpecProvider : SpecProviderDecorator
     {
         spec.ArbOsVersion = arbosVersion;
 
+        // Arbitrum Stylus support: Allow larger code sizes
+        spec.MaxCodeSize = 131072;      // 128 KB (vs Ethereum's 24 KB)
+
         // Shanghai EIPs (ArbOS v11+)
         bool shanghaiEnabled = arbosVersion >= ArbosVersion.Eleven;
         spec.IsEip3651Enabled = shanghaiEnabled;
@@ -76,5 +79,8 @@ public sealed class ArbitrumDynamicSpecProvider : SpecProviderDecorator
 
         // Disable contract code validation as Arbitrum stores Stylus bytecode
         spec.IsEip3541Enabled = false;
+
+        // Arbitrum supports larger contracts than Ethereum (128KB+ for Stylus)
+        spec.IsEip170Enabled = false;
     }
 }


### PR DESCRIPTION
Fixes Closes #539 

Arbitrum Stylus WASM contracts exceed Ethereum's 24KB code size limit (EIP-170), so Nitro sets MaxCodeSize = 128KB and MaxInitCodeSize = 256KB to accommodate them. Without this fix, Nethermind rejects these deployments with "EIP-3860 - transaction size over max init code size or calculates long.MaxValue as the gas cost, causing blockhash missmatches on big contracts. 

- PR for System Test https://github.com/NethermindEth/arbitrum-nitro/pull/53
