### PR TITLE
Performance/Memory Improvement on ExecutionEnvironment

### DIFF
--- a/src/Nethermind.Arbitrum/Execution/ArbitrumTransactionProcessor.cs
+++ b/src/Nethermind.Arbitrum/Execution/ArbitrumTransactionProcessor.cs
@@ -64,6 +64,7 @@ namespace Nethermind.Arbitrum.Execution
             _tracingInfo?.Dispose();
             _tracingInfo = newTracingInfo;
         }
+
         private IReleaseSpec? _currentSpec;
         private BlockHeader? _currentHeader;
         private ExecutionOptions _currentOpts;

--- a/src/Nethermind.Arbitrum/Tracing/TracingInfo.cs
+++ b/src/Nethermind.Arbitrum/Tracing/TracingInfo.cs
@@ -48,7 +48,6 @@ public class TracingInfo : IDisposable
         _env = null;
     }
 
-
     public void RecordStorageGet(ValueHash256 key)
     {
         if (!Tracer.IsTracingStorage)


### PR DESCRIPTION
### Fix ExecutionEnvironment pool

### Summary

- Fix `ExecutionEnvironment` pool starvation by implementing proper disposal in `TracingInfo`

### Problem

### Issue: `ExecutionEnvironment` Pool Starvation

`ExecutionEnvironment` objects were being Rent()'d from an object pool but never Dispose()'d, causing pool starvation. This affected every transaction processed by the node.

Root cause: `TracingInfo` stored a reference to the rented `ExecutionEnvironment` but never implemented `IDisposable`. When _tracingInfo was reassigned (which happens multiple times per transaction), the previous `ExecutionEnvironment` was orphaned and never returned to the pool.

Leak locations in ArbitrumTransactionProcessor.cs:
- `InitializeTransactionState()` - called for every transaction
- `StartTracer()` - called for Arbitrum-specific transaction types
- `ProcessArbitrumTransaction()` finally block - called after Arbitrum tx processing

Impact:
- Pool remains empty, every `Rent()` allocates a new object
- Increased GC pressure from continuous allocations
- Defeats the purpose of object pooling entirely

Contrast with proper pattern in base Nethermind (TransactionProcessor.cs):
`using ExecutionEnvironment env = e;`  // Properly wrapped in using

### Solution

### Fix: `TracingInfo` disposal

Made `TracingInfo` implement `IDisposable` and added a `SetTracingInfo()` helper method that disposes the old `TracingInfo` before assigning a new one:

```
private void SetTracingInfo(TracingInfo? newTracingInfo)
{
    _tracingInfo?.Dispose();
    _tracingInfo = newTracingInfo;
}
```