### PR TITLE
fix: Return empty struct instead of string for Nitro RPC compatibility

### DIFF
--- a/src/Nethermind.Arbitrum.Test/Rpc/NitroExecutionRpcModuleSetFinalityDataTests.cs
+++ b/src/Nethermind.Arbitrum.Test/Rpc/NitroExecutionRpcModuleSetFinalityDataTests.cs
@@ -26,7 +26,7 @@ namespace Nethermind.Arbitrum.Test.Rpc;
 [TestFixture]
 public sealed class NitroExecutionRpcModuleSetFinalityDataTests
 {
-    private const string ExpectedSuccessResponse = """{"jsonrpc":"2.0","result":"OK","id":67}""";
+    private const string ExpectedSuccessResponse = """{"jsonrpc":"2.0","result":{},"id":67}""";
 
     /// <summary>
     /// Tests that nitroexecution_setFinalityData correctly handles explicit null values
@@ -42,7 +42,7 @@ public sealed class NitroExecutionRpcModuleSetFinalityDataTests
     {
         IArbitrumExecutionEngine engine = Substitute.For<IArbitrumExecutionEngine>();
         engine.SetFinalityData(Arg.Any<SetFinalityDataParams>())
-            .Returns(ResultWrapper<string>.Success("OK"));
+            .Returns(ResultWrapper<EmptyResponse>.Success(default));
 
         INitroExecutionRpcModule module = new NitroExecutionRpcModule(engine);
 
@@ -71,7 +71,7 @@ public sealed class NitroExecutionRpcModuleSetFinalityDataTests
     {
         IArbitrumExecutionEngine engine = Substitute.For<IArbitrumExecutionEngine>();
         engine.SetFinalityData(Arg.Any<SetFinalityDataParams>())
-            .Returns(ResultWrapper<string>.Success("OK"));
+            .Returns(ResultWrapper<EmptyResponse>.Success(default));
 
         INitroExecutionRpcModule module = new NitroExecutionRpcModule(engine);
 
@@ -97,7 +97,7 @@ public sealed class NitroExecutionRpcModuleSetFinalityDataTests
     {
         IArbitrumExecutionEngine engine = Substitute.For<IArbitrumExecutionEngine>();
         engine.SetFinalityData(Arg.Any<SetFinalityDataParams>())
-            .Returns(ResultWrapper<string>.Success("OK"));
+            .Returns(ResultWrapper<EmptyResponse>.Success(default));
 
         INitroExecutionRpcModule module = new NitroExecutionRpcModule(engine);
 
@@ -127,7 +127,7 @@ public sealed class NitroExecutionRpcModuleSetFinalityDataTests
         SetFinalityDataParams? capturedParams = null;
         IArbitrumExecutionEngine engine = Substitute.For<IArbitrumExecutionEngine>();
         engine.SetFinalityData(Arg.Do<SetFinalityDataParams>(p => capturedParams = p))
-            .Returns(ResultWrapper<string>.Success("OK"));
+            .Returns(ResultWrapper<EmptyResponse>.Success(default));
 
         INitroExecutionRpcModule module = new NitroExecutionRpcModule(engine);
 

--- a/src/Nethermind.Arbitrum/Data/EmptyResponse.cs
+++ b/src/Nethermind.Arbitrum/Data/EmptyResponse.cs
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Arbitrum.Data;
+
+/// <summary>
+/// Represents an empty RPC response. Serializes to <c>{}</c> in JSON.
+/// Used for methods where Nitro expects an empty struct response.
+/// </summary>
+public readonly struct EmptyResponse;

--- a/src/Nethermind.Arbitrum/Execution/ArbitrumExecutionEngine.cs
+++ b/src/Nethermind.Arbitrum/Execution/ArbitrumExecutionEngine.cs
@@ -263,7 +263,7 @@ public sealed class ArbitrumExecutionEngine(
         }
     }
 
-    public ResultWrapper<string> SetFinalityData(SetFinalityDataParams parameters)
+    public ResultWrapper<EmptyResponse> SetFinalityData(SetFinalityDataParams parameters)
     {
         try
         {
@@ -283,37 +283,37 @@ public sealed class ArbitrumExecutionEngine(
             if (_logger.IsDebug)
                 _logger.Debug("SetFinalityData completed successfully");
 
-            return ResultWrapper<string>.Success("OK");
+            return ResultWrapper<EmptyResponse>.Success(default);
         }
         catch (Exception ex)
         {
             if (_logger.IsError)
                 _logger.Error($"SetFinalityData failed: {ex.Message}", ex);
 
-            return ResultWrapper<string>.Fail(ArbitrumRpcErrors.InternalError);
+            return ResultWrapper<EmptyResponse>.Fail(ArbitrumRpcErrors.InternalError);
         }
     }
 
-    public ResultWrapper<string> MarkFeedStart(ulong to)
+    public ResultWrapper<EmptyResponse> MarkFeedStart(ulong to)
     {
         try
         {
             cachedL1PriceData.MarkFeedStart(to);
-            return ResultWrapper<string>.Success("OK");
+            return ResultWrapper<EmptyResponse>.Success(default);
         }
         catch (Exception ex)
         {
             if (_logger.IsError)
                 _logger.Error($"MarkFeedStart failed: {ex.Message}", ex);
 
-            return ResultWrapper<string>.Fail(ArbitrumRpcErrors.InternalError);
+            return ResultWrapper<EmptyResponse>.Fail(ArbitrumRpcErrors.InternalError);
         }
     }
 
-    public ResultWrapper<string> SetConsensusSyncData(SetConsensusSyncDataParams? parameters)
+    public ResultWrapper<EmptyResponse> SetConsensusSyncData(SetConsensusSyncDataParams? parameters)
     {
         if (parameters is null)
-            return ResultWrapper<string>.Fail("Parameters cannot be null", ErrorCodes.InvalidParams);
+            return ResultWrapper<EmptyResponse>.Fail("Parameters cannot be null", ErrorCodes.InvalidParams);
 
         try
         {
@@ -323,14 +323,14 @@ public sealed class ArbitrumExecutionEngine(
                 parameters.SyncProgressMap,
                 parameters.UpdatedAt);
 
-            return ResultWrapper<string>.Success("OK");
+            return ResultWrapper<EmptyResponse>.Success(default);
         }
         catch (Exception ex)
         {
             if (_logger.IsError)
                 _logger.Error($"SetConsensusSyncData failed: {ex.Message}", ex);
 
-            return ResultWrapper<string>.Fail(ArbitrumRpcErrors.InternalError);
+            return ResultWrapper<EmptyResponse>.Fail(ArbitrumRpcErrors.InternalError);
         }
     }
 

--- a/src/Nethermind.Arbitrum/Execution/ArbitrumExecutionEngineWithComparison.cs
+++ b/src/Nethermind.Arbitrum/Execution/ArbitrumExecutionEngineWithComparison.cs
@@ -45,10 +45,10 @@ public sealed class ArbitrumExecutionEngineWithComparison(
     public ResultWrapper<ulong> BlockNumberToMessageIndex(ulong blockNumber)
         => innerEngine.BlockNumberToMessageIndex(blockNumber);
 
-    public ResultWrapper<string> SetFinalityData(SetFinalityDataParams parameters)
+    public ResultWrapper<EmptyResponse> SetFinalityData(SetFinalityDataParams parameters)
         => innerEngine.SetFinalityData(parameters);
 
-    public ResultWrapper<string> MarkFeedStart(ulong to)
+    public ResultWrapper<EmptyResponse> MarkFeedStart(ulong to)
         => innerEngine.MarkFeedStart(to);
 
     public Task<ResultWrapper<string>> TriggerMaintenanceAsync()
@@ -63,7 +63,7 @@ public sealed class ArbitrumExecutionEngineWithComparison(
     public ResultWrapper<MessageResult> DigestInitMessage(DigestInitMessage message)
         => innerEngine.DigestInitMessage(message);
 
-    public ResultWrapper<string> SetConsensusSyncData(SetConsensusSyncDataParams? parameters)
+    public ResultWrapper<EmptyResponse> SetConsensusSyncData(SetConsensusSyncDataParams? parameters)
         => innerEngine.SetConsensusSyncData(parameters);
 
     public ResultWrapper<bool> Synced()

--- a/src/Nethermind.Arbitrum/Execution/IArbitrumExecutionEngine.cs
+++ b/src/Nethermind.Arbitrum/Execution/IArbitrumExecutionEngine.cs
@@ -17,13 +17,13 @@ public interface IArbitrumExecutionEngine
     Task<ResultWrapper<ulong>> HeadMessageIndexAsync();
     ResultWrapper<long> MessageIndexToBlockNumber(ulong messageIndex);
     ResultWrapper<ulong> BlockNumberToMessageIndex(ulong blockNumber);
-    ResultWrapper<string> SetFinalityData(SetFinalityDataParams parameters);
-    ResultWrapper<string> MarkFeedStart(ulong to);
+    ResultWrapper<EmptyResponse> SetFinalityData(SetFinalityDataParams parameters);
+    ResultWrapper<EmptyResponse> MarkFeedStart(ulong to);
     Task<ResultWrapper<string>> TriggerMaintenanceAsync();
     Task<ResultWrapper<bool>> ShouldTriggerMaintenanceAsync();
     Task<ResultWrapper<MaintenanceStatus>> MaintenanceStatusAsync();
     ResultWrapper<MessageResult> DigestInitMessage(DigestInitMessage message);
-    ResultWrapper<string> SetConsensusSyncData(SetConsensusSyncDataParams? parameters);
+    ResultWrapper<EmptyResponse> SetConsensusSyncData(SetConsensusSyncDataParams? parameters);
     ResultWrapper<bool> Synced();
     ResultWrapper<Dictionary<string, object>> FullSyncProgressMap();
     Task<ResultWrapper<ulong>> ArbOSVersionForMessageIndexAsync(ulong messageIndex);

--- a/src/Nethermind.Arbitrum/Modules/ArbitrumRpcErrors.cs
+++ b/src/Nethermind.Arbitrum/Modules/ArbitrumRpcErrors.cs
@@ -9,7 +9,7 @@ namespace Nethermind.Arbitrum.Modules
         public const string InternalError = "Internal error processing request";
 
         public static string BlockNotFound(long blockNumber) =>
-            $"Block {blockNumber} not found or not synced";
+            $"result not found";
 
         public static string FormatNullParameters() =>
             "Parameters cannot be null";

--- a/src/Nethermind.Arbitrum/Modules/ArbitrumRpcModule.cs
+++ b/src/Nethermind.Arbitrum/Modules/ArbitrumRpcModule.cs
@@ -3,12 +3,14 @@
 
 using Nethermind.Arbitrum.Data;
 using Nethermind.Arbitrum.Execution;
+using Nethermind.Core;
 using Nethermind.JsonRpc;
 
 namespace Nethermind.Arbitrum.Modules;
 
 /// <summary>
 /// RPC module for the "Arbitrum" namespace. Thin facade that delegates to IArbitrumExecutionEngine.
+/// Legacy namespace - converts EmptyResponse to "OK" for backwards compatibility.
 /// </summary>
 public class ArbitrumRpcModule(IArbitrumExecutionEngine engine) : IArbitrumRpcModule
 {
@@ -34,13 +36,28 @@ public class ArbitrumRpcModule(IArbitrumExecutionEngine engine) : IArbitrumRpcMo
         => Task.FromResult(engine.BlockNumberToMessageIndex(blockNumber));
 
     public ResultWrapper<string> SetFinalityData(SetFinalityDataParams parameters)
-        => engine.SetFinalityData(parameters);
+    {
+        ResultWrapper<EmptyResponse> result = engine.SetFinalityData(parameters);
+        return result.Result == Result.Success
+            ? ResultWrapper<string>.Success("OK")
+            : ResultWrapper<string>.Fail(result.Result.Error!, result.ErrorCode);
+    }
 
     public ResultWrapper<string> MarkFeedStart(ulong to)
-        => engine.MarkFeedStart(to);
+    {
+        ResultWrapper<EmptyResponse> result = engine.MarkFeedStart(to);
+        return result.Result == Result.Success
+            ? ResultWrapper<string>.Success("OK")
+            : ResultWrapper<string>.Fail(result.Result.Error!, result.ErrorCode);
+    }
 
     public ResultWrapper<string> SetConsensusSyncData(SetConsensusSyncDataParams? parameters)
-        => engine.SetConsensusSyncData(parameters);
+    {
+        ResultWrapper<EmptyResponse> result = engine.SetConsensusSyncData(parameters);
+        return result.Result == Result.Success
+            ? ResultWrapper<string>.Success("OK")
+            : ResultWrapper<string>.Fail(result.Result.Error!, result.ErrorCode);
+    }
 
     public ResultWrapper<bool> Synced()
         => engine.Synced();

--- a/src/Nethermind.Arbitrum/Modules/INitroExecutionRpcModule.cs
+++ b/src/Nethermind.Arbitrum/Modules/INitroExecutionRpcModule.cs
@@ -39,16 +39,16 @@ public interface INitroExecutionRpcModule : IRpcModule
     Task<ResultWrapper<MessageIndex>> nitroexecution_blockNumberToMessageIndex(ulong blockNumber);
 
     [JsonRpcMethod(IsSharable = false, IsImplemented = true)]
-    ResultWrapper<string> nitroexecution_setFinalityData(
+    ResultWrapper<EmptyResponse> nitroexecution_setFinalityData(
         RpcFinalityData? safeFinalityData,
         RpcFinalityData? finalizedFinalityData,
         RpcFinalityData? validatedFinalityData);
 
     [JsonRpcMethod(IsSharable = false, IsImplemented = true)]
-    ResultWrapper<string> nitroexecution_setConsensusSyncData(SetConsensusSyncDataParams syncData);
+    ResultWrapper<EmptyResponse> nitroexecution_setConsensusSyncData(SetConsensusSyncDataParams syncData);
 
     [JsonRpcMethod(IsSharable = false, IsImplemented = true)]
-    ResultWrapper<string> nitroexecution_markFeedStart(MessageIndex to);
+    ResultWrapper<EmptyResponse> nitroexecution_markFeedStart(MessageIndex to);
 
     [JsonRpcMethod(IsSharable = false, IsImplemented = true)]
     Task<ResultWrapper<string>> nitroexecution_triggerMaintenance();

--- a/src/Nethermind.Arbitrum/Modules/NitroExecutionRpcModule.cs
+++ b/src/Nethermind.Arbitrum/Modules/NitroExecutionRpcModule.cs
@@ -48,7 +48,7 @@ public class NitroExecutionRpcModule(IArbitrumExecutionEngine engine) : INitroEx
         return Task.FromResult(ResultWrapper<MessageIndex>.From(result, (MessageIndex)result.Data));
     }
 
-    public ResultWrapper<string> nitroexecution_setFinalityData(
+    public ResultWrapper<EmptyResponse> nitroexecution_setFinalityData(
         RpcFinalityData? safeFinalityData,
         RpcFinalityData? finalizedFinalityData,
         RpcFinalityData? validatedFinalityData)
@@ -62,10 +62,10 @@ public class NitroExecutionRpcModule(IArbitrumExecutionEngine engine) : INitroEx
         return engine.SetFinalityData(parameters);
     }
 
-    public ResultWrapper<string> nitroexecution_setConsensusSyncData(SetConsensusSyncDataParams syncData)
+    public ResultWrapper<EmptyResponse> nitroexecution_setConsensusSyncData(SetConsensusSyncDataParams syncData)
         => engine.SetConsensusSyncData(syncData);
 
-    public ResultWrapper<string> nitroexecution_markFeedStart(MessageIndex to)
+    public ResultWrapper<EmptyResponse> nitroexecution_markFeedStart(MessageIndex to)
         => engine.MarkFeedStart(to);
 
     public Task<ResultWrapper<string>> nitroexecution_triggerMaintenance()


### PR DESCRIPTION
Change return types from `ResultWrapper<string>` to `ResultWrapper<EmptyResponse>` for `SetFinalityData`, `SetConsensusSyncData,` and `MarkFeedStart` methods.

Nitro expects `struct{}` (serializes to `{}`) but Nethermind was returning "OK" (string), causing JSON unmarshal errors: 
```
json: cannot unmarshal string into Go value of type struct {}
```

This became required after Nitro PR 

- https://github.com/OffchainLabs/nitro/pull/4278

refactored the RPC client to properly decode response bodies instead of discarding them