### PR TITLE
ci: add automated Nethermind submodule update workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
   notify-submodule-failure:
     name: Notify Submodule Update Failure
     needs: build
-    if: failure() && startsWith(github.head_ref, 'auto/nethermind-update')
+    if: needs.build.result == 'failure' && startsWith(github.head_ref, 'auto/nethermind-update')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -56,6 +56,11 @@ jobs:
           REPO: ${{ github.repository }}
           SERVER_URL: ${{ github.server_url }}
         run: |
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No PR number found, skipping notification"
+            exit 0
+          fi
+
           gh pr comment "$PR_NUMBER" \
             --repo "$REPO" \
             --body "## ⚠️ Build Failure Detected

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   format:
@@ -34,3 +35,43 @@ jobs:
 
       - name: Check code format
         run: dotnet format ${{ matrix.project }} --verify-no-changes
+
+  # Notify on failure for automated submodule update PRs
+  notify-submodule-failure:
+    name: Notify Submodule Update Failure
+    needs: format
+    if: needs.format.result == 'failure' && startsWith(github.head_ref, 'auto/nethermind-update')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Post failure comment on PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_ID: ${{ github.run_id }}
+          REPO: ${{ github.repository }}
+          SERVER_URL: ${{ github.server_url }}
+        run: |
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No PR number found, skipping notification"
+            exit 0
+          fi
+
+          gh pr comment "$PR_NUMBER" \
+            --repo "$REPO" \
+            --body "## ⚠️ Format Check Failure Detected
+
+          The Nethermind submodule update introduced a format check failure.
+
+          **Failed Job:** format
+          **Workflow Run:** $SERVER_URL/$REPO/actions/runs/$RUN_ID
+
+          Please review the failure and either:
+          1. Fix compatibility in a follow-up commit
+          2. Close this PR and wait for upstream fix
+          3. Pin to a specific working commit"
+
+          gh pr edit "$PR_NUMBER" \
+            --repo "$REPO" \
+            --add-label "breaking-change"

--- a/.github/workflows/submodule-update.yml
+++ b/.github/workflows/submodule-update.yml
@@ -9,6 +9,10 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: submodule-update
+  cancel-in-progress: true
+
 jobs:
   check-for-updates:
     runs-on: ubuntu-latest
@@ -129,28 +133,32 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SHORT_SHA: ${{ steps.update.outputs.short-sha }}
         run: |
-          # Read changelog from file (safer than inline expansion)
-          CHANGELOG=$(cat /tmp/changelog.txt)
+          # Build PR body in a file to handle special characters safely
+          PR_BODY_FILE=/tmp/pr_body.md
+
+          {
+            echo "## Automated Submodule Update"
+            echo
+            echo "This PR updates the Nethermind submodule from \`$CURRENT_SHA\` to \`$LATEST_SHA\`."
+            echo
+            echo "### Changes ($COMMIT_COUNT commits)"
+            echo
+            cat /tmp/changelog.txt
+            echo
+            echo "[View full diff on GitHub](https://github.com/NethermindEth/nethermind/compare/${CURRENT_SHA}...${LATEST_SHA})"
+            echo
+            echo "### CI Checks"
+            echo "- [ ] Build"
+            echo "- [ ] Unit Tests"
+            echo "- [ ] Format Check"
+            echo "- [ ] Comparison Tests (manual trigger recommended)"
+            echo
+            echo "---"
+            echo "*This PR was automatically created by the submodule update workflow.*"
+          } > "$PR_BODY_FILE"
 
           gh pr create \
             --title "chore(deps): Update Nethermind submodule ($COMMIT_COUNT commits)" \
-            --body "## Automated Submodule Update
-
-          This PR updates the Nethermind submodule from \`$CURRENT_SHA\` to \`$LATEST_SHA\`.
-
-          ### Changes ($COMMIT_COUNT commits)
-
-          $CHANGELOG
-
-          [View full diff on GitHub](https://github.com/NethermindEth/nethermind/compare/${CURRENT_SHA}...${LATEST_SHA})
-
-          ### CI Checks
-          - [ ] Build
-          - [ ] Unit Tests
-          - [ ] Format Check
-          - [ ] Comparison Tests (manual trigger recommended)
-
-          ---
-          *This PR was automatically created by the submodule update workflow.*" \
+            --body-file "$PR_BODY_FILE" \
             --label "dependencies" \
             --label "automated"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
   notify-submodule-failure:
     name: Notify Submodule Update Failure
     needs: test
-    if: failure() && startsWith(github.head_ref, 'auto/nethermind-update')
+    if: needs.test.result == 'failure' && startsWith(github.head_ref, 'auto/nethermind-update')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -62,6 +62,11 @@ jobs:
           REPO: ${{ github.repository }}
           SERVER_URL: ${{ github.server_url }}
         run: |
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No PR number found, skipping notification"
+            exit 0
+          fi
+
           gh pr comment "$PR_NUMBER" \
             --repo "$REPO" \
             --body "## ⚠️ Test Failure Detected


### PR DESCRIPTION
## Summary

  Adds automated daily compatibility checking for the Nethermind submodule dependency.

  ### How it works

  ```mermaid
  flowchart TD
      A[⏰ Daily 5 AM UTC] --> B{Check Nethermind master}
      B -->|No new commits| C[✅ Exit - up to date]
      B -->|New commits found| D[Create branch<br/>auto/nethermind-update-YYYYMMDD]
      D --> E[Update submodule reference]
      E --> F[Create PR with changelog]
      F --> G[CI Runs]

      G --> H{Build}
      G --> I{Test}
      G --> J{Format}

      H -->|Pass| K[✅]
      H -->|Fail| L[💬 Comment + 🏷️ breaking-change]

      I -->|Pass| M[✅]
      I -->|Fail| L

      J -->|Pass| N[✅]
      J -->|Fail| O[Standard failure]

      K & M & N --> P[👤 Manual review & merge]
      L --> Q[👤 Review failure & decide]
```

  What it does

  - Daily check at 5 AM UTC: Detects new commits on Nethermind master branch
  - Auto-creates PRs: When updates exist, creates auto/nethermind-update-YYYYMMDD branch with PR
  - Changelog in PR body: Lists up to 20 recent upstream commits with link to full diff
  - Failure notifications: Comments on PR and adds breaking-change label when CI fails
  - Duplicate prevention: Skips if branch/PR already exists for today