### PR TITLE
Revert: Part of Stylus NuGet package not copied to build output (#696)

### DIFF
--- a/src/Nethermind.Arbitrum/Stylus/ArbitrumInitializeStylusNative.cs
+++ b/src/Nethermind.Arbitrum/Stylus/ArbitrumInitializeStylusNative.cs
@@ -1,55 +1,21 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: https://github.com/NethermindEth/nethermind-arbitrum/blob/main/LICENSE.md
 
-using System.Runtime.InteropServices;
 using Nethermind.Api.Steps;
-using Nethermind.Logging;
 
 namespace Nethermind.Arbitrum.Stylus;
 
-public class ArbitrumInitializeStylusNative(IStylusTargetConfig config, ILogManager? logManager = null) : IStep
+public class ArbitrumInitializeStylusNative(IStylusTargetConfig api) : IStep
 {
-    private const string StylusLibraryName = "stylus";
-    private readonly ILogger _logger = (logManager ?? NullLogManager.Instance).GetClassLogger<ArbitrumInitializeStylusNative>();
-
     public Task Execute(CancellationToken cancellationToken)
     {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        VerifyStylusNativeLibrary();
-
-        cancellationToken.ThrowIfCancellationRequested();
+        IStylusTargetConfig config = api;
 
         StylusNative.SetWasmLruCacheCapacity(Math.Utils.SaturateMul(config.NativeLruCacheCapacityMb, 1024 * 1024ul));
         PopulateStylusTargetCache(config);
 
         return Task.CompletedTask;
     }
-
-    private void VerifyStylusNativeLibrary()
-    {
-        string localTarget = StylusTargets.GetLocalTargetName();
-
-        if (!NativeLibrary.TryLoad(StylusLibraryName, typeof(StylusNative).Assembly,
-                DllImportSearchPath.AssemblyDirectory, out nint handle))
-        {
-            string expectedFile = GetExpectedLibraryFileName();
-            throw new InvalidOperationException(
-                $"Failed to load Stylus native library for target '{localTarget}'. " +
-                $"Ensure the Nethermind.Arbitrum.Stylus NuGet package is correctly installed " +
-                $"and the native library for your platform is present. " +
-                $"Expected file: runtimes/{localTarget}/native/{expectedFile}");
-        }
-
-        NativeLibrary.Free(handle);
-
-        if (_logger.IsInfo)
-            _logger.Info($"Stylus native library verified for {localTarget}");
-    }
-
-    private static string GetExpectedLibraryFileName() =>
-        RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "stylus.dll" :
-        RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "libstylus.dylib" : "libstylus.so";
 
     private static void PopulateStylusTargetCache(IStylusTargetConfig config)
     {
@@ -59,7 +25,7 @@ public class ArbitrumInitializeStylusNative(IStylusTargetConfig config, ILogMana
         bool nativeSet = false;
         foreach (string target in targets)
         {
-            if (target == StylusTargets.WavmTargetName)
+            if (target == StylusTargets.WavmTargetName) // WAVM is unknown target for WASM compiler (wasmer) and handled separately
                 continue;
 
             string effectiveStylusTarget = target switch


### PR DESCRIPTION
Fixes following error on node start:

<img width="2000" height="1280" alt="error" src="https://github.com/user-attachments/assets/df307fad-6543-4d35-b785-086e1f2428c5" />