### PR TITLE
Avoid redundant List allocation in block production

### DIFF
--- a/src/Nethermind.Arbitrum/Execution/ArbitrumBlockProcessor.cs
+++ b/src/Nethermind.Arbitrum/Execution/ArbitrumBlockProcessor.cs
@@ -476,7 +476,7 @@ namespace Nethermind.Arbitrum.Execution
                     return [];
                 }
 
-                List<Transaction> addedTransactions = new(lastTxReceipt.Logs!.Length);
+                List<Transaction> addedTransactions = new();
 
                 if (lastTxReceipt.Logs != null)
                 {


### PR DESCRIPTION
#### Eliminated Redundant `.ToList()` Copy in Block Production Hot Path

`GetScheduledTransactions` already returned a concrete `List<Transaction>` but was typed as `IEnumerable<Transaction>`. The caller immediately invoked `.ToList()`, creating an identical copy solely to allow iterating the collection twice.

By changing the return type to `List<Transaction>`, the extra allocation is no longer necessary. The same list can now be safely iterated by both `AdjustGasForScheduledRedeems` and the `foreach` loop without materialising a duplicate collection.