### PR TITLE
Align CalculateEffectiveGasPrice tip-drop with Nitro's evm.Context.BaseFee

### DIFF
--- a/src/Nethermind.Arbitrum.Test/Execution/ArbitrumTransactionProcessorTests.cs
+++ b/src/Nethermind.Arbitrum.Test/Execution/ArbitrumTransactionProcessorTests.cs
@@ -55,8 +55,6 @@ public class ArbitrumTransactionProcessorTests
 
         Block genesis = ArbOSInitialization.Create(worldState);
 
-        BlockTree blockTree = Build.A.BlockTree(genesis).OfChainLength(1).TestObject;
-
         ArbitrumVirtualMachine virtualMachine = new(
             ArbOSInitialization.GetSpecHelper(),
             new TestBlockhashProvider(GetSpecProvider()),
@@ -143,7 +141,6 @@ public class ArbitrumTransactionProcessorTests
 
         Block genesis = ArbOSInitialization.Create(worldState);
 
-        BlockTree blockTree = Build.A.BlockTree(genesis).OfChainLength(1).TestObject;
         ArbitrumVirtualMachine virtualMachine = new(
             ArbOSInitialization.GetSpecHelper(),
             new TestBlockhashProvider(GetSpecProvider()),
@@ -172,7 +169,7 @@ public class ArbitrumTransactionProcessorTests
         UInt256 value = 0;
         long gasLimit = GasCostOf.Transaction;
 
-        ArbitrumRetryTransaction transaction = new ArbitrumRetryTransaction
+        ArbitrumRetryTransaction transaction = new()
         {
             ChainId = 0,
             Nonce = 0,
@@ -209,8 +206,6 @@ public class ArbitrumTransactionProcessorTests
         using IDisposable worldStateDisposer = worldState.BeginScope(IWorldState.PreGenesis);
 
         Block genesis = ArbOSInitialization.Create(worldState);
-
-        BlockTree blockTree = Build.A.BlockTree(genesis).OfChainLength(1).TestObject;
 
         ArbitrumVirtualMachine virtualMachine = new(
             ArbOSInitialization.GetSpecHelper(),
@@ -273,9 +268,6 @@ public class ArbitrumTransactionProcessorTests
 
         Block genesis = ArbOSInitialization.Create(worldState);
 
-        BlockTree blockTree = Build.A.BlockTree(genesis).OfChainLength(1).TestObject;
-
-
         ArbitrumVirtualMachine virtualMachine = new(
             ArbOSInitialization.GetSpecHelper(),
             new TestBlockhashProvider(GetSpecProvider()),
@@ -325,8 +317,6 @@ public class ArbitrumTransactionProcessorTests
         using IDisposable worldStateDisposer = worldState.BeginScope(IWorldState.PreGenesis);
 
         Block genesis = ArbOSInitialization.Create(worldState);
-
-        BlockTree blockTree = Build.A.BlockTree(genesis).OfChainLength(1).TestObject;
 
         ArbitrumVirtualMachine virtualMachine = new(
             ArbOSInitialization.GetSpecHelper(),
@@ -1230,7 +1220,7 @@ public class ArbitrumTransactionProcessorTests
     {
         UInt256 l1BaseFee = 39;
 
-        Action<ContainerBuilder> preConfigurer = (ContainerBuilder cb) =>
+        Action<ContainerBuilder> preConfigurer = cb =>
         {
             cb.AddScoped(new ArbitrumTestBlockchainBase.Configuration()
             {
@@ -1385,7 +1375,7 @@ public class ArbitrumTransactionProcessorTests
     {
         UInt256 l1BaseFee = 39;
 
-        Action<ContainerBuilder> preConfigurer = (ContainerBuilder cb) =>
+        Action<ContainerBuilder> preConfigurer = cb =>
         {
             cb.AddScoped(new ArbitrumTestBlockchainBase.Configuration()
             {
@@ -1614,94 +1604,6 @@ public class ArbitrumTransactionProcessorTests
     }
 
     [Test]
-    public void ArbitrumTransaction_WithArbitrumBlockHeader_ProcessesCorrectly()
-    {
-        // Test ArbitrumBlockHeader approach: EVM sees BaseFeePerGas=0, gas calculations use OriginalBaseFee.
-        // In NoBaseFee mode, tip-drop compares against baseFee (0), so effective gas price becomes 0.
-
-        IWorldState worldState = TestWorldStateFactory.CreateForTest();
-        using IDisposable worldStateDisposer = worldState.BeginScope(IWorldState.PreGenesis);
-
-        Block genesis = ArbOSInitialization.Create(worldState);
-
-        BlockTree blockTree = Build.A.BlockTree(genesis).OfChainLength(1).TestObject;
-
-        ArbitrumVirtualMachine virtualMachine = new(
-            ArbOSInitialization.GetSpecHelper(),
-            new TestBlockhashProvider(GetSpecProvider()),
-            TestWasmStore.Create(),
-            GetSpecProvider(),
-            _logManager
-        );
-
-        UInt256 blockBaseFee = (UInt256)500;
-        UInt256 originalBaseFee = (UInt256)1000;
-
-        genesis.Header.BaseFeePerGas = blockBaseFee;
-
-        ArbitrumChainSpecEngineParameters chainSpecParams = new() { GenesisBlockNum = 0 };
-        ArbitrumBlockHeader arbitrumHeader = new(genesis.Header, originalBaseFee, (long)chainSpecParams.GenesisBlockNum!);
-        arbitrumHeader.BaseFeePerGas = 0; // Set to 0 for EVM execution (NoBaseFee behavior)
-
-        BlockExecutionContext blCtx = new(arbitrumHeader, GetSpecProvider().GetSpec(arbitrumHeader));
-        virtualMachine.SetBlockExecutionContext(in blCtx);
-
-        ArbitrumTransactionProcessor processor = new(
-            BlobBaseFeeCalculator.Instance,
-            GetSpecProvider(),
-            worldState,
-            TestWasmStore.Create(),
-            virtualMachine,
-            _logManager,
-            new EthereumCodeInfoRepository(worldState)
-        );
-
-        // Verify NoBaseFee behavior - EVM sees 0
-        virtualMachine.BlockExecutionContext.Header.BaseFeePerGas.Should().Be(UInt256.Zero,
-            "ArbitrumBlockHeader with NoBaseFee should have EVM BaseFee = 0");
-
-        // Verify we're using ArbitrumBlockHeader
-        virtualMachine.BlockExecutionContext.Header.Should().BeOfType<ArbitrumBlockHeader>(
-            "Should be using ArbitrumBlockHeader");
-
-        ArbitrumBlockHeader arbitrumBlockHeader = (ArbitrumBlockHeader)virtualMachine.BlockExecutionContext.Header;
-        arbitrumBlockHeader.OriginalBaseFee.Should().Be(originalBaseFee,
-            "ArbitrumBlockHeader should store original base fee");
-
-        Address sender = TestItem.AddressA;
-        Address to = TestItem.AddressB;
-        UInt256 value = 100;
-        long gasLimit = 30000;
-
-        Transaction transaction = Build.A.Transaction
-            .WithSenderAddress(sender)
-            .WithTo(to)
-            .WithValue(value)
-            .WithGasLimit(gasLimit)
-            .WithGasPrice(originalBaseFee)
-            .WithNonce(0)
-            .SignedAndResolved(TestItem.PrivateKeyA)
-            .TestObject;
-
-        UInt256 requiredBalance = originalBaseFee * (ulong)gasLimit + value;
-        worldState.CreateAccount(sender, requiredBalance, 0);
-
-        ArbitrumGethLikeTxTracer tracer = new(GethTraceOptions.Default);
-        TransactionResult result = processor.Execute(transaction, tracer);
-
-        result.Should().Be(TransactionResult.Ok);
-        transaction.SpentGas.Should().BeGreaterThan(0);
-
-        UInt256 finalBalance = worldState.GetBalance(sender);
-        UInt256 actualGasCost = requiredBalance - finalBalance - value;
-
-        // In NoBaseFee mode, tip-drop sets effective gas price to baseFee (0), matching Nitro.
-        actualGasCost.Should().Be(UInt256.Zero,
-            "In NoBaseFee mode, tip-drop sets effective gas price to header.BaseFeePerGas (0), "
-            + "matching Nitro's state_transition.go:execute which uses evm.Context.BaseFee");
-    }
-
-    [Test]
     public void ArbitrumTransaction_WithoutNoBaseFee_UsesBlockBaseFee()
     {
         // Test that without NoBaseFee, transactions should use the block's BaseFeePerGas
@@ -1711,7 +1613,6 @@ public class ArbitrumTransactionProcessorTests
 
         Block genesis = ArbOSInitialization.Create(worldState);
 
-        BlockTree blockTree = Build.A.BlockTree(genesis).OfChainLength(1).TestObject;
 
         ArbitrumVirtualMachine virtualMachine = new(
             ArbOSInitialization.GetSpecHelper(),
@@ -1791,7 +1692,6 @@ public class ArbitrumTransactionProcessorTests
 
         Block genesis = ArbOSInitialization.Create(worldState);
 
-        BlockTree blockTree = Build.A.BlockTree(genesis).OfChainLength(1).TestObject;
 
         ArbitrumVirtualMachine virtualMachine = new(
             ArbOSInitialization.GetSpecHelper(),
@@ -1907,7 +1807,6 @@ public class ArbitrumTransactionProcessorTests
         using IDisposable worldStateDisposer = worldState.BeginScope(IWorldState.PreGenesis);
 
         Block genesis = ArbOSInitialization.Create(worldState);
-        BlockTree blockTree = Build.A.BlockTree(genesis).OfChainLength(1).TestObject;
 
         ArbitrumVirtualMachine virtualMachine = new(
             ArbOSInitialization.GetSpecHelper(),
@@ -1990,7 +1889,6 @@ public class ArbitrumTransactionProcessorTests
         using IDisposable worldStateDisposer = worldState.BeginScope(IWorldState.PreGenesis);
 
         Block genesis = ArbOSInitialization.Create(worldState);
-        BlockTree blockTree = Build.A.BlockTree(genesis).OfChainLength(1).TestObject;
 
         ArbitrumVirtualMachine virtualMachine = new(
             ArbOSInitialization.GetSpecHelper(),
@@ -2095,7 +1993,6 @@ public class ArbitrumTransactionProcessorTests
         using IDisposable worldStateDisposer = worldState.BeginScope(IWorldState.PreGenesis);
 
         Block genesis = ArbOSInitialization.Create(worldState);
-        BlockTree blockTree = Build.A.BlockTree(genesis).OfChainLength(1).TestObject;
 
         ArbitrumVirtualMachine virtualMachine = new(
             ArbOSInitialization.GetSpecHelper(),
@@ -2179,7 +2076,6 @@ public class ArbitrumTransactionProcessorTests
         using IDisposable worldStateDisposer = worldState.BeginScope(IWorldState.PreGenesis);
 
         Block genesis = ArbOSInitialization.Create(worldState);
-        BlockTree blockTree = Build.A.BlockTree(genesis).OfChainLength(1).TestObject;
 
         ArbitrumVirtualMachine virtualMachine = new(
             ArbOSInitialization.GetSpecHelper(),
@@ -3189,7 +3085,6 @@ public class ArbitrumTransactionProcessorTests
         using IDisposable worldStateDisposer = worldState.BeginScope(IWorldState.PreGenesis);
 
         Block genesis = ArbOSInitialization.Create(worldState);
-        BlockTree blockTree = Build.A.BlockTree(genesis).OfChainLength(1).TestObject;
 
         ArbitrumVirtualMachine virtualMachine = new(
             ArbOSInitialization.GetSpecHelper(),
@@ -3282,7 +3177,6 @@ public class ArbitrumTransactionProcessorTests
         using IDisposable worldStateDisposer = worldState.BeginScope(IWorldState.PreGenesis);
 
         Block genesis = ArbOSInitialization.Create(worldState);
-        BlockTree blockTree = Build.A.BlockTree(genesis).OfChainLength(1).TestObject;
 
         ArbitrumVirtualMachine virtualMachine = new(
             ArbOSInitialization.GetSpecHelper(),
@@ -3306,9 +3200,6 @@ public class ArbitrumTransactionProcessorTests
             _logManager,
             new EthereumCodeInfoRepository(worldState)
         );
-
-        SystemBurner burner = new(readOnly: false);
-        ArbosState arbosState = ArbosState.OpenArbosState(worldState, burner, _logManager.GetClassLogger<ArbosState>());
 
         Hash256 ticketIdHash = ArbRetryableTxTests.Hash256FromUlong(456);
         Address sender = TestItem.AddressA;
@@ -3641,7 +3532,6 @@ public class ArbitrumTransactionProcessorTests
     private static Transaction CreateTransactionForType(TxType txType)
     {
         if (txType == TxType.Legacy)
-        {
             return Build.A.Transaction
                 .WithType(TxType.Legacy)
                 .WithTo(TestItem.AddressB)
@@ -3651,7 +3541,6 @@ public class ArbitrumTransactionProcessorTests
                 .WithNonce(1)
                 .SignedAndResolved(TestItem.PrivateKeyA)
                 .TestObject;
-        }
 
         return txType switch
         {

--- a/src/Nethermind.Arbitrum.Test/Execution/ArbitrumTransactionProcessorTests.cs
+++ b/src/Nethermind.Arbitrum.Test/Execution/ArbitrumTransactionProcessorTests.cs
@@ -1604,7 +1604,7 @@ public class ArbitrumTransactionProcessorTests
     }
 
     [Test]
-    public void ArbitrumTransaction_WithoutNoBaseFee_UsesBlockBaseFee()
+    public void ArbitrumTransaction_WithoutOriginalBaseFee_UsesBlockBaseFee()
     {
         // Test that without NoBaseFee, transactions should use the block's BaseFeePerGas
 
@@ -1682,10 +1682,11 @@ public class ArbitrumTransactionProcessorTests
     }
 
     [Test]
-    public void ArbitrumTransaction_WithArbitrumBlockHeader_UsesOriginalBaseFeeForGasCalculations()
+    public void ArbitrumTransaction_WithOriginalBaseFee_NoBaseFeeModeTipDropChargesZero()
     {
-        // Test that ArbitrumBlockHeader stores OriginalBaseFee while EVM sees BaseFeePerGas=0.
-        // In NoBaseFee mode, tip-drop compares against baseFee (0), so effective gas price becomes 0.
+        // Simulates eth_call with non-zero gasPrice where tip gets dropped.
+        // In Nitro go-ethereum:consensus-v51/core/state_transition.go:execute, the tip-drop sets msg.GasPrice = evm.Context.BaseFee,
+        // which is 0 during eth_call. Nethermind should match: charge at BaseFeePerGas (0), not OriginalBaseFee.
 
         IWorldState worldState = TestWorldStateFactory.CreateForTest();
         using IDisposable worldStateDisposer = worldState.BeginScope(IWorldState.PreGenesis);
@@ -3783,76 +3784,5 @@ public class ArbitrumTransactionProcessorTests
         UInt256 expectedInfraCost = minBaseFee * gasLimit;
         actualInfraFee.Should().Be(expectedInfraCost,
             $"When minBaseFee ({minBaseFee}) < effectiveBaseFee ({effectiveBaseFee}), should use minBaseFee");
-    }
-
-    [Test]
-    public void CalculateEffectiveGasPrice_NoBaseFeeTipDrop_ChargesAtZeroNotOriginalBaseFee()
-    {
-        // Simulates eth_call with non-zero gasPrice where tip gets dropped.
-        // In Nitro go-ethereum:consensus-v51/core/state_transition.go:execute, the tip-drop sets msg.GasPrice = evm.Context.BaseFee,
-        // which is 0 during eth_call. Nethermind should match: charge at BaseFeePerGas (0), not OriginalBaseFee.
-
-        IWorldState worldState = TestWorldStateFactory.CreateForTest();
-        using IDisposable worldStateDisposer = worldState.BeginScope(IWorldState.PreGenesis);
-
-        Block genesis = ArbOSInitialization.Create(worldState);
-
-        ArbitrumVirtualMachine virtualMachine = new(
-            ArbOSInitialization.GetSpecHelper(),
-            new TestBlockhashProvider(GetSpecProvider()),
-            TestWasmStore.Create(),
-            GetSpecProvider(),
-            _logManager
-        );
-
-        UInt256 originalBaseFee = (UInt256)1000;
-        UInt256 gasPrice = (UInt256)5000; // Higher than originalBaseFee → triggers tip-drop
-
-        ArbitrumChainSpecEngineParameters chainSpecParams = new() { GenesisBlockNum = 0 };
-        ArbitrumBlockHeader arbitrumHeader = new(genesis.Header, originalBaseFee, (long)chainSpecParams.GenesisBlockNum!);
-        arbitrumHeader.BaseFeePerGas = 0; // NoBaseFee mode (eth_call)
-
-        BlockExecutionContext blCtx = new(arbitrumHeader, GetSpecProvider().GetSpec(arbitrumHeader));
-        virtualMachine.SetBlockExecutionContext(in blCtx);
-
-        ArbitrumTransactionProcessor processor = new(
-            BlobBaseFeeCalculator.Instance,
-            GetSpecProvider(),
-            worldState,
-            TestWasmStore.Create(),
-            virtualMachine,
-            _logManager,
-            new EthereumCodeInfoRepository(worldState)
-        );
-
-        Address sender = TestItem.AddressA;
-        Address to = TestItem.AddressB;
-        UInt256 value = 100;
-        long gasLimit = 30000;
-
-        Transaction transaction = Build.A.Transaction
-            .WithSenderAddress(sender)
-            .WithTo(to)
-            .WithValue(value)
-            .WithGasLimit(gasLimit)
-            .WithGasPrice(gasPrice)
-            .WithNonce(0)
-            .SignedAndResolved(TestItem.PrivateKeyA)
-            .TestObject;
-
-        // Give sender enough balance to pass validation (gasPrice * gasLimit + value)
-        UInt256 requiredBalance = gasPrice * (ulong)gasLimit + value;
-        worldState.CreateAccount(sender, requiredBalance, 0);
-
-        ArbitrumGethLikeTxTracer tracer = new(GethTraceOptions.Default);
-        TransactionResult result = processor.Execute(transaction, tracer);
-        result.Should().Be(TransactionResult.Ok);
-
-        UInt256 finalBalance = worldState.GetBalance(sender);
-        UInt256 actualGasCost = requiredBalance - finalBalance - value;
-
-        actualGasCost.Should().Be(UInt256.Zero,
-            "In NoBaseFee mode with tip-drop, effective gas price should be header.BaseFeePerGas (0), "
-            + "not OriginalBaseFee — matching Nitro's state_transition.go:execute which uses evm.Context.BaseFee");
     }
 }

--- a/src/Nethermind.Arbitrum.Test/Execution/ArbitrumTransactionProcessorTests.cs
+++ b/src/Nethermind.Arbitrum.Test/Execution/ArbitrumTransactionProcessorTests.cs
@@ -1616,7 +1616,8 @@ public class ArbitrumTransactionProcessorTests
     [Test]
     public void ArbitrumTransaction_WithArbitrumBlockHeader_ProcessesCorrectly()
     {
-        // Test NEW ArbitrumBlockHeader approach: EVM sees 0, gas calculations use original base fee
+        // Test ArbitrumBlockHeader approach: EVM sees BaseFeePerGas=0, gas calculations use OriginalBaseFee.
+        // In NoBaseFee mode, tip-drop compares against baseFee (0), so effective gas price becomes 0.
 
         IWorldState worldState = TestWorldStateFactory.CreateForTest();
         using IDisposable worldStateDisposer = worldState.BeginScope(IWorldState.PreGenesis);
@@ -1688,21 +1689,16 @@ public class ArbitrumTransactionProcessorTests
         ArbitrumGethLikeTxTracer tracer = new(GethTraceOptions.Default);
         TransactionResult result = processor.Execute(transaction, tracer);
 
-        // Assert transaction executes successfully
         result.Should().Be(TransactionResult.Ok);
         transaction.SpentGas.Should().BeGreaterThan(0);
 
-        UInt256 initialBalance = requiredBalance;
         UInt256 finalBalance = worldState.GetBalance(sender);
-        UInt256 actualGasCost = initialBalance - finalBalance - value;
-        UInt256 expectedGasCost = (UInt256)transaction.SpentGas * originalBaseFee;
+        UInt256 actualGasCost = requiredBalance - finalBalance - value;
 
-        // The critical test: Gas should be charged using originalBaseFee from ArbitrumBlockHeader
-        actualGasCost.Should().Be(expectedGasCost,
-            "Gas should be charged using original base fee (1000) from ArbitrumBlockHeader.OriginalBaseFee");
-
-        actualGasCost.Should().BeGreaterThan(0,
-            "Some gas should be charged - proves the ArbitrumBlockHeader approach is working");
+        // In NoBaseFee mode, tip-drop sets effective gas price to baseFee (0), matching Nitro.
+        actualGasCost.Should().Be(UInt256.Zero,
+            "In NoBaseFee mode, tip-drop sets effective gas price to header.BaseFeePerGas (0), "
+            + "matching Nitro's state_transition.go:execute which uses evm.Context.BaseFee");
     }
 
     [Test]
@@ -1787,8 +1783,8 @@ public class ArbitrumTransactionProcessorTests
     [Test]
     public void ArbitrumTransaction_WithArbitrumBlockHeader_UsesOriginalBaseFeeForGasCalculations()
     {
-        // Test that with ArbitrumBlockHeader, transactions use original base fee for gas calculations
-        // but EVM sees 0 base fee
+        // Test that ArbitrumBlockHeader stores OriginalBaseFee while EVM sees BaseFeePerGas=0.
+        // In NoBaseFee mode, tip-drop compares against baseFee (0), so effective gas price becomes 0.
 
         IWorldState worldState = TestWorldStateFactory.CreateForTest();
         using IDisposable worldStateDisposer = worldState.BeginScope(IWorldState.PreGenesis);
@@ -1859,15 +1855,13 @@ public class ArbitrumTransactionProcessorTests
         result.Should().Be(TransactionResult.Ok);
         transaction.SpentGas.Should().BeGreaterThan(0);
 
-        // Verify gas was charged using original BaseFee (for gas calculations)
-        // even though EVM sees BaseFee = 0
-        UInt256 initialBalance = requiredBalance;
         UInt256 finalBalance = worldState.GetBalance(sender);
-        UInt256 actualGasCost = initialBalance - finalBalance - value;
-        UInt256 expectedGasCost = (UInt256)transaction.SpentGas * originalBaseFee;
+        UInt256 actualGasCost = requiredBalance - finalBalance - value;
 
-        actualGasCost.Should().Be(expectedGasCost,
-            $"With ArbitrumBlockHeader, gas should be charged using original BaseFee ({originalBaseFee}) for gas calculations");
+        // In NoBaseFee mode, tip-drop sets effective gas price to baseFee (0), matching Nitro.
+        actualGasCost.Should().Be(UInt256.Zero,
+            "In NoBaseFee mode, tip-drop sets effective gas price to header.BaseFeePerGas (0), "
+            + "matching Nitro's state_transition.go:execute which uses evm.Context.BaseFee");
     }
 
     [Test]
@@ -3900,5 +3894,76 @@ public class ArbitrumTransactionProcessorTests
         UInt256 expectedInfraCost = minBaseFee * gasLimit;
         actualInfraFee.Should().Be(expectedInfraCost,
             $"When minBaseFee ({minBaseFee}) < effectiveBaseFee ({effectiveBaseFee}), should use minBaseFee");
+    }
+
+    [Test]
+    public void CalculateEffectiveGasPrice_NoBaseFeeTipDrop_ChargesAtZeroNotOriginalBaseFee()
+    {
+        // Simulates eth_call with non-zero gasPrice where tip gets dropped.
+        // In Nitro go-ethereum:consensus-v51/core/state_transition.go:execute, the tip-drop sets msg.GasPrice = evm.Context.BaseFee,
+        // which is 0 during eth_call. Nethermind should match: charge at BaseFeePerGas (0), not OriginalBaseFee.
+
+        IWorldState worldState = TestWorldStateFactory.CreateForTest();
+        using IDisposable worldStateDisposer = worldState.BeginScope(IWorldState.PreGenesis);
+
+        Block genesis = ArbOSInitialization.Create(worldState);
+
+        ArbitrumVirtualMachine virtualMachine = new(
+            ArbOSInitialization.GetSpecHelper(),
+            new TestBlockhashProvider(GetSpecProvider()),
+            TestWasmStore.Create(),
+            GetSpecProvider(),
+            _logManager
+        );
+
+        UInt256 originalBaseFee = (UInt256)1000;
+        UInt256 gasPrice = (UInt256)5000; // Higher than originalBaseFee → triggers tip-drop
+
+        ArbitrumChainSpecEngineParameters chainSpecParams = new() { GenesisBlockNum = 0 };
+        ArbitrumBlockHeader arbitrumHeader = new(genesis.Header, originalBaseFee, (long)chainSpecParams.GenesisBlockNum!);
+        arbitrumHeader.BaseFeePerGas = 0; // NoBaseFee mode (eth_call)
+
+        BlockExecutionContext blCtx = new(arbitrumHeader, GetSpecProvider().GetSpec(arbitrumHeader));
+        virtualMachine.SetBlockExecutionContext(in blCtx);
+
+        ArbitrumTransactionProcessor processor = new(
+            BlobBaseFeeCalculator.Instance,
+            GetSpecProvider(),
+            worldState,
+            TestWasmStore.Create(),
+            virtualMachine,
+            _logManager,
+            new EthereumCodeInfoRepository(worldState)
+        );
+
+        Address sender = TestItem.AddressA;
+        Address to = TestItem.AddressB;
+        UInt256 value = 100;
+        long gasLimit = 30000;
+
+        Transaction transaction = Build.A.Transaction
+            .WithSenderAddress(sender)
+            .WithTo(to)
+            .WithValue(value)
+            .WithGasLimit(gasLimit)
+            .WithGasPrice(gasPrice)
+            .WithNonce(0)
+            .SignedAndResolved(TestItem.PrivateKeyA)
+            .TestObject;
+
+        // Give sender enough balance to pass validation (gasPrice * gasLimit + value)
+        UInt256 requiredBalance = gasPrice * (ulong)gasLimit + value;
+        worldState.CreateAccount(sender, requiredBalance, 0);
+
+        ArbitrumGethLikeTxTracer tracer = new(GethTraceOptions.Default);
+        TransactionResult result = processor.Execute(transaction, tracer);
+        result.Should().Be(TransactionResult.Ok);
+
+        UInt256 finalBalance = worldState.GetBalance(sender);
+        UInt256 actualGasCost = requiredBalance - finalBalance - value;
+
+        actualGasCost.Should().Be(UInt256.Zero,
+            "In NoBaseFee mode with tip-drop, effective gas price should be header.BaseFeePerGas (0), "
+            + "not OriginalBaseFee — matching Nitro's state_transition.go:execute which uses evm.Context.BaseFee");
     }
 }

--- a/src/Nethermind.Arbitrum/Execution/ArbitrumTransactionProcessor.cs
+++ b/src/Nethermind.Arbitrum/Execution/ArbitrumTransactionProcessor.cs
@@ -278,14 +278,15 @@ namespace Nethermind.Arbitrum.Execution
         {
             opcodeGasPrice = tx.CalculateEffectiveGasPrice(eip1559Enabled, in baseFee);
 
+            // effectiveGasPrice relies on OriginalBaseFee (not the potentially-zeroed baseFee), matching Nitro's
+            // TransactionToMessage which computes msg.GasPrice with the real header BaseFee before zeroing.
             UInt256 effectiveBaseFee = VirtualMachine.BlockExecutionContext.GetEffectiveBaseFeeForGasCalculations();
             UInt256 effectiveGasPrice = tx.CalculateEffectiveGasPrice(eip1559Enabled, in effectiveBaseFee);
 
-            // Drop tip if necessary (Arbitrum-specific logic)
-            if (ShouldDropTip(VirtualMachine.BlockExecutionContext, _arbosState!.CurrentArbosVersion) && effectiveGasPrice > effectiveBaseFee)
-            {
-                return effectiveBaseFee;
-            }
+            // Tip-drop uses baseFee (not effectiveBaseFee), matching Nitro's
+            // go-ethereum:consensus-v51/core/state_transition.go:execute which uses evm.Context.BaseFee.
+            if (ShouldDropTip(VirtualMachine.BlockExecutionContext, _arbosState!.CurrentArbosVersion) && effectiveGasPrice > baseFee)
+                return baseFee;
 
             return effectiveGasPrice;
         }


### PR DESCRIPTION
`CalculateEffectiveGasPrice` used `OriginalBaseFee` (Nitro's `BaseFeeInBlock`) for the tip-drop comparison and return value. Nitro's [`state_transition.go:execute`](https://github.com/OffchainLabs/go-ethereum/blob/consensus-v51/core/state_transition.go#L600) uses `evm.Context.BaseFee` instead, which is zeroed during `eth_call` (NoBaseFee mode).

During block processing there is no divergence (`baseFee == OriginalBaseFee`). During `eth_call` with a non-zero `gasPrice` and tip-dropping active, Nethermind returned `OriginalBaseFee` (e.g. 1000) while Nitro returned 0. This could cause `eth_call` to fail with insufficient balance when Nitro would succeed.

Same class of bug as the `TryCalculatePremiumPerGas` fix in #809, in a different method within the same file.
