### PR TITLE
feat: log status message on initialization

### DIFF
--- a/src/Nethermind.Arbitrum.Test/Infrastructure/ArbitrumRpcTestBlockchain.cs
+++ b/src/Nethermind.Arbitrum.Test/Infrastructure/ArbitrumRpcTestBlockchain.cs
@@ -407,7 +407,7 @@ public class ArbitrumRpcTestBlockchain : ArbitrumTestBlockchainBase
             chain.Container.Resolve<SequencerState>().Activate();
         }
 
-        chain.NitroExecutionRpcModule = new NitroExecutionRpcModule(engine);
+        chain.NitroExecutionRpcModule = new NitroExecutionRpcModule(engine, chain.Container.Resolve<ArbitrumClHealthTracker>());
         chain.ArbitrumEthRpcModule = CreateEthRpcModule(chain);
 
         return chain;

--- a/src/Nethermind.Arbitrum.Test/Rpc/NitroExecutionRpcModuleSetFinalityDataTests.cs
+++ b/src/Nethermind.Arbitrum.Test/Rpc/NitroExecutionRpcModuleSetFinalityDataTests.cs
@@ -3,9 +3,11 @@
 
 using System.Text.Json;
 using FluentAssertions;
+using Nethermind.Arbitrum.Config;
 using Nethermind.Arbitrum.Data;
 using Nethermind.Arbitrum.Execution;
 using Nethermind.Arbitrum.Modules;
+using Nethermind.Logging;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
 using Nethermind.JsonRpc.Test;
@@ -43,7 +45,7 @@ public sealed class NitroExecutionRpcModuleSetFinalityDataTests
         engine.SetFinalityData(Arg.Any<SetFinalityDataParams>())
             .Returns(ResultWrapper.EmptySuccess);
 
-        INitroExecutionRpcModule module = new NitroExecutionRpcModule(engine);
+        INitroExecutionRpcModule module = new NitroExecutionRpcModule(engine, new ArbitrumClHealthTracker(LimboLogs.Instance));
 
         RpcFinalityData safeData = new() { MsgIdx = 100, BlockHash = TestItem.KeccakA };
         RpcFinalityData finalizedData = new() { MsgIdx = 100, BlockHash = TestItem.KeccakA };
@@ -72,7 +74,7 @@ public sealed class NitroExecutionRpcModuleSetFinalityDataTests
         engine.SetFinalityData(Arg.Any<SetFinalityDataParams>())
             .Returns(ResultWrapper.EmptySuccess);
 
-        INitroExecutionRpcModule module = new NitroExecutionRpcModule(engine);
+        INitroExecutionRpcModule module = new NitroExecutionRpcModule(engine, new ArbitrumClHealthTracker(LimboLogs.Instance));
 
         string response = await RpcTest.TestSerializedRequest(
             module,
@@ -98,7 +100,7 @@ public sealed class NitroExecutionRpcModuleSetFinalityDataTests
         engine.SetFinalityData(Arg.Any<SetFinalityDataParams>())
             .Returns(ResultWrapper.EmptySuccess);
 
-        INitroExecutionRpcModule module = new NitroExecutionRpcModule(engine);
+        INitroExecutionRpcModule module = new NitroExecutionRpcModule(engine, new ArbitrumClHealthTracker(LimboLogs.Instance));
 
         RpcFinalityData finalizedData = new() { MsgIdx = 50, BlockHash = TestItem.KeccakB };
 
@@ -128,7 +130,7 @@ public sealed class NitroExecutionRpcModuleSetFinalityDataTests
         engine.SetFinalityData(Arg.Do<SetFinalityDataParams>(p => capturedParams = p))
             .Returns(ResultWrapper.EmptySuccess);
 
-        INitroExecutionRpcModule module = new NitroExecutionRpcModule(engine);
+        INitroExecutionRpcModule module = new NitroExecutionRpcModule(engine, new ArbitrumClHealthTracker(LimboLogs.Instance));
 
         Hash256 safeHash = TestItem.KeccakA;
         Hash256 finalizedHash = TestItem.KeccakB;

--- a/src/Nethermind.Arbitrum/ArbitrumPlugin.cs
+++ b/src/Nethermind.Arbitrum/ArbitrumPlugin.cs
@@ -103,6 +103,8 @@ public class ArbitrumPlugin(ChainSpec chainSpec, IBlocksConfig blocksConfig, IAr
         if (!_specHelper.Enabled)
             return Task.CompletedTask;
 
+        ILogger logger = _api.LogManager.GetClassLogger<ArbitrumPlugin>();
+
         IArbitrumExecutionEngine engine = _api.Context.Resolve<IArbitrumExecutionEngine>();
 
         if (arbitrumConfig.SequencerEnabled)
@@ -118,7 +120,6 @@ public class ArbitrumPlugin(ChainSpec chainSpec, IBlocksConfig blocksConfig, IAr
             if (string.IsNullOrWhiteSpace(verifyBlockHashConfig.ArbNodeRpcUrl))
                 throw new InvalidOperationException("Block hash verification is enabled but ArbNodeRpcUrl is not specified. Please configure VerifyBlockHash.ArbNodeRpcUrl or disable verification.");
 
-            ILogger logger = _api.LogManager.GetClassLogger<ArbitrumPlugin>();
             if (logger.IsInfo)
                 logger.Info($"Block hash verification enabled: verify every {verifyBlockHashConfig.VerifyEveryNBlocks} blocks, url={verifyBlockHashConfig.ArbNodeRpcUrl}");
 
@@ -171,6 +172,9 @@ public class ArbitrumPlugin(ChainSpec chainSpec, IBlocksConfig blocksConfig, IAr
                 preBlockCaches);
             _api.RpcModuleProvider.RegisterSingle(debugModule);
         }
+
+        if (logger.IsInfo)
+            logger.Info("Arbitrum execution client initialized. Waiting for connection from consensus layer...");
 
         return Task.CompletedTask;
     }

--- a/src/Nethermind.Arbitrum/ArbitrumPlugin.cs
+++ b/src/Nethermind.Arbitrum/ArbitrumPlugin.cs
@@ -135,7 +135,9 @@ public class ArbitrumPlugin(ChainSpec chainSpec, IBlocksConfig blocksConfig, IAr
         _api.RpcModuleProvider.RegisterSingle(arbitrumRpcModule);
 
         // Register nitroexecution namespace
-        INitroExecutionRpcModule nitroRpcModule = new NitroExecutionRpcModule(engine);
+        ArbitrumClHealthTracker clHealthTracker = _api.Context.Resolve<ArbitrumClHealthTracker>();
+        _ = clHealthTracker.StartAsync();
+        INitroExecutionRpcModule nitroRpcModule = new NitroExecutionRpcModule(engine, clHealthTracker);
         _api.RpcModuleProvider.RegisterSingle(nitroRpcModule);
 
         _api.RpcModuleProvider.RegisterBounded(
@@ -246,7 +248,6 @@ public class ArbitrumModule(ChainSpec chainSpec, IBlocksConfig blocksConfig, IAr
             .AddSingleton<IArbitrumSpecHelper, ArbitrumSpecHelper>()
             .AddSingleton<ArbitrumClHealthTracker>()
             .Bind<IClHealthTracker, ArbitrumClHealthTracker>()
-            .Bind<IEngineRequestsTracker, ArbitrumClHealthTracker>()
 
             .AddStep(typeof(ArbitrumInitializeBlockchain))
             .AddStep(typeof(ArbitrumInitializeWasmDb))

--- a/src/Nethermind.Arbitrum/ArbitrumPlugin.cs
+++ b/src/Nethermind.Arbitrum/ArbitrumPlugin.cs
@@ -103,8 +103,6 @@ public class ArbitrumPlugin(ChainSpec chainSpec, IBlocksConfig blocksConfig, IAr
         if (!_specHelper.Enabled)
             return Task.CompletedTask;
 
-        ILogger logger = _api.LogManager.GetClassLogger<ArbitrumPlugin>();
-
         IArbitrumExecutionEngine engine = _api.Context.Resolve<IArbitrumExecutionEngine>();
 
         if (arbitrumConfig.SequencerEnabled)
@@ -120,6 +118,7 @@ public class ArbitrumPlugin(ChainSpec chainSpec, IBlocksConfig blocksConfig, IAr
             if (string.IsNullOrWhiteSpace(verifyBlockHashConfig.ArbNodeRpcUrl))
                 throw new InvalidOperationException("Block hash verification is enabled but ArbNodeRpcUrl is not specified. Please configure VerifyBlockHash.ArbNodeRpcUrl or disable verification.");
 
+            ILogger logger = _api.LogManager.GetClassLogger<ArbitrumPlugin>();
             if (logger.IsInfo)
                 logger.Info($"Block hash verification enabled: verify every {verifyBlockHashConfig.VerifyEveryNBlocks} blocks, url={verifyBlockHashConfig.ArbNodeRpcUrl}");
 
@@ -173,8 +172,7 @@ public class ArbitrumPlugin(ChainSpec chainSpec, IBlocksConfig blocksConfig, IAr
             _api.RpcModuleProvider.RegisterSingle(debugModule);
         }
 
-        if (logger.IsInfo)
-            logger.Info("Arbitrum execution client initialized. Waiting for connection from consensus layer...");
+        ThisNodeInfo.AddInfo("Arbitrum     :", "Waiting for connection from consensus layer...");
 
         return Task.CompletedTask;
     }

--- a/src/Nethermind.Arbitrum/ArbitrumPlugin.cs
+++ b/src/Nethermind.Arbitrum/ArbitrumPlugin.cs
@@ -172,8 +172,6 @@ public class ArbitrumPlugin(ChainSpec chainSpec, IBlocksConfig blocksConfig, IAr
             _api.RpcModuleProvider.RegisterSingle(debugModule);
         }
 
-        ThisNodeInfo.AddInfo("Arbitrum     :", "Waiting for connection from consensus layer...");
-
         return Task.CompletedTask;
     }
 
@@ -246,8 +244,9 @@ public class ArbitrumModule(ChainSpec chainSpec, IBlocksConfig blocksConfig, IAr
             .AddSingleton<NethermindApi, ArbitrumNethermindApi>()
             .AddSingleton(chainSpecParams)
             .AddSingleton<IArbitrumSpecHelper, ArbitrumSpecHelper>()
-            .AddSingleton<IClHealthTracker, NoOpClHealthTracker>()
-            .AddSingleton<IEngineRequestsTracker, NoOpClHealthTracker>()
+            .AddSingleton<ArbitrumClHealthTracker>()
+            .Bind<IClHealthTracker, ArbitrumClHealthTracker>()
+            .Bind<IEngineRequestsTracker, ArbitrumClHealthTracker>()
 
             .AddStep(typeof(ArbitrumInitializeBlockchain))
             .AddStep(typeof(ArbitrumInitializeWasmDb))

--- a/src/Nethermind.Arbitrum/Config/ArbitrumClHealthTracker.cs
+++ b/src/Nethermind.Arbitrum/Config/ArbitrumClHealthTracker.cs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: https://github.com/NethermindEth/nethermind-arbitrum/blob/main/LICENSE.md
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Nethermind.Api;
+using Nethermind.HealthChecks;
+using Nethermind.Logging;
+
+namespace Nethermind.Arbitrum.Config;
+
+public class ArbitrumClHealthTracker(ILogManager logManager) : IClHealthTracker, IEngineRequestsTracker, IAsyncDisposable
+{
+    private static readonly TimeSpan InitialDelay = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan CheckInterval = TimeSpan.FromSeconds(30);
+
+    private readonly ILogger _logger = logManager.GetClassLogger<ArbitrumClHealthTracker>();
+    private volatile bool _connected;
+    private Timer? _timer;
+
+    public Task StartAsync()
+    {
+        _timer = new Timer(CheckConnection, null, InitialDelay, CheckInterval);
+        return Task.CompletedTask;
+    }
+
+    public bool CheckClAlive() => _connected;
+
+    public void OnForkchoiceUpdatedCalled() => MarkConnected();
+
+    public void OnNewPayloadCalled() => MarkConnected();
+
+    private void MarkConnected()
+    {
+        if (_connected) return;
+        _connected = true;
+        _timer?.Change(Timeout.Infinite, 0);
+    }
+
+    private void CheckConnection(object? _)
+    {
+        if (_connected) return;
+
+        if (_logger.IsInfo)
+            _logger.Info("Waiting for connection from consensus layer...");
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _timer?.Change(Timeout.Infinite, 0);
+        if (_timer is not null) await _timer.DisposeAsync();
+    }
+}

--- a/src/Nethermind.Arbitrum/Config/ArbitrumClHealthTracker.cs
+++ b/src/Nethermind.Arbitrum/Config/ArbitrumClHealthTracker.cs
@@ -4,13 +4,12 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Nethermind.Api;
 using Nethermind.HealthChecks;
 using Nethermind.Logging;
 
 namespace Nethermind.Arbitrum.Config;
 
-public class ArbitrumClHealthTracker(ILogManager logManager) : IClHealthTracker, IEngineRequestsTracker, IAsyncDisposable
+public class ArbitrumClHealthTracker(ILogManager logManager) : IClHealthTracker, IAsyncDisposable
 {
     private static readonly TimeSpan InitialDelay = TimeSpan.FromSeconds(30);
     private static readonly TimeSpan CheckInterval = TimeSpan.FromSeconds(30);
@@ -27,11 +26,7 @@ public class ArbitrumClHealthTracker(ILogManager logManager) : IClHealthTracker,
 
     public bool CheckClAlive() => _connected;
 
-    public void OnForkchoiceUpdatedCalled() => MarkConnected();
-
-    public void OnNewPayloadCalled() => MarkConnected();
-
-    private void MarkConnected()
+    public void MarkConnected()
     {
         if (_connected) return;
         _connected = true;

--- a/src/Nethermind.Arbitrum/Config/ArbitrumClHealthTracker.cs
+++ b/src/Nethermind.Arbitrum/Config/ArbitrumClHealthTracker.cs
@@ -28,14 +28,17 @@ public class ArbitrumClHealthTracker(ILogManager logManager) : IClHealthTracker,
 
     public void MarkConnected()
     {
-        if (_connected) return;
+        if (_connected)
+            return;
+
         _connected = true;
         _timer?.Change(Timeout.Infinite, 0);
     }
 
     private void CheckConnection(object? _)
     {
-        if (_connected) return;
+        if (_connected)
+            return;
 
         if (_logger.IsInfo)
             _logger.Info("Waiting for connection from consensus layer...");
@@ -44,6 +47,7 @@ public class ArbitrumClHealthTracker(ILogManager logManager) : IClHealthTracker,
     public async ValueTask DisposeAsync()
     {
         _timer?.Change(Timeout.Infinite, 0);
-        if (_timer is not null) await _timer.DisposeAsync();
+        if (_timer is not null)
+            await _timer.DisposeAsync();
     }
 }

--- a/src/Nethermind.Arbitrum/Modules/NitroExecutionRpcModule.cs
+++ b/src/Nethermind.Arbitrum/Modules/NitroExecutionRpcModule.cs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: https://github.com/NethermindEth/nethermind-arbitrum/blob/main/LICENSE.md
 
+using Nethermind.Arbitrum.Config;
 using Nethermind.Arbitrum.Data;
 using Nethermind.Arbitrum.Execution;
 using Nethermind.JsonRpc;
@@ -10,13 +11,14 @@ namespace Nethermind.Arbitrum.Modules;
 /// <summary>
 /// RPC module for the "nitroexecution" namespace. Thin facade that delegates to IArbitrumExecutionEngine.
 /// </summary>
-public class NitroExecutionRpcModule(IArbitrumExecutionEngine engine) : INitroExecutionRpcModule
+public class NitroExecutionRpcModule(IArbitrumExecutionEngine engine, ArbitrumClHealthTracker clHealthTracker) : INitroExecutionRpcModule
 {
     public Task<ResultWrapper<MessageResult>> nitroexecution_digestMessage(
         MessageIndex msgIdx,
         MessageWithMetadata message,
         MessageWithMetadata? messageForPrefetch)
     {
+        clHealthTracker.MarkConnected();
         DigestMessageParameters parameters = new(msgIdx, message, messageForPrefetch);
         return engine.DigestMessageAsync(parameters);
     }


### PR DESCRIPTION
## Summary

When nethermind-arbitrum finishes initialization, it currently produces no log output indicating it is ready and waiting for the consensus layer. Other Nethermind chains (e.g. Merge plugin) display "Waiting for..." messages during this phase.

This PR adds an INFO-level log message at the end of `InitRpcModules()`:

```
Arbitrum execution client initialized. Waiting for connection from consensus layer...
```

Also hoists the logger declaration to method scope to avoid a redundant `GetClassLogger` call inside the block hash verification branch.

Closes #605

## Changes

- `ArbitrumPlugin.cs`: Move `ILogger` instantiation to top of `InitRpcModules()`, add status log at end

## Testing

- Build passes (`dotnet build`)
- All existing tests pass (1738/1740 passed; 2 aborted due to OOM on test host, unrelated)