### PR TITLE
fix: bump github-workflows to v2.0.0 and add artifact-metadata:write

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -30,6 +30,7 @@ concurrency:
 permissions:
   id-token: write
   attestations: write
+  artifact-metadata: write
   contents: read
 
 jobs:
@@ -44,7 +45,7 @@ jobs:
           - platform: linux/amd64
             runner: ubuntu-latest
             arch_suffix: -amd64
-    uses: NethermindEth/github-workflows/.github/workflows/docker-build-push-jfrog.yaml@v1.11.4
+    uses: NethermindEth/github-workflows/.github/workflows/docker-build-push-jfrog.yaml@v2.0.0
     with:
       runner: ${{ matrix.runner }}
       group_name: core


### PR DESCRIPTION
## Summary
- Bump `NethermindEth/github-workflows` to v2.0.0
- Add `artifact-metadata: write` to workflow permissions

## Breaking change in upstream
`github-workflows` v2.0.0 now requires the `artifact-metadata: write` permission for `actions/attest-build-provenance`.

See: https://github.blog/changelog/2026-01-13-new-fine-grained-permission-for-artifact-metadata-is-now-generally-available/