### PR TITLE
Fix client to properly migrate Stylus contract to Wasmer 7 (serialize version 16)

### DIFF
--- a/src/Nethermind.Arbitrum/Stylus/ArbitrumInitializeWasmDb.cs
+++ b/src/Nethermind.Arbitrum/Stylus/ArbitrumInitializeWasmDb.cs
@@ -18,7 +18,7 @@ using Nethermind.Logging;
 
 namespace Nethermind.Arbitrum.Stylus;
 
-[RunnerStepDependencies([typeof(InitializeBlockchain)], [typeof(StartBlockProcessor)])]
+[RunnerStepDependencies([typeof(InitializeBlockchain), typeof(ArbitrumInitializeStylusNative)], [typeof(StartBlockProcessor)])]
 public class ArbitrumInitializeWasmDb(
     IWasmDb wasmDb,
     [KeyFilter("code")] IDb codeDb,

--- a/src/Nethermind.Arbitrum/Stylus/WasmDb.cs
+++ b/src/Nethermind.Arbitrum/Stylus/WasmDb.cs
@@ -169,50 +169,45 @@ public sealed class WasmDb : IWasmDb
     /// </summary>
     public DeleteWasmResult DeleteWasmEntries(IReadOnlyList<ReadOnlyMemory<byte>> prefixes, int? expectedKeyLength = null)
     {
-        int deletedCount = 0;
+        // Snapshot iteration before any Remove. The wasm DB is configured with prefix_hash
+        // memtable + capped:8 prefix_extractor (see ArbitrumDbConfigFactory); a tailing iterator
+        // with concurrent Remove on this DB silently skips matching keys, leaving stale
+        // wrong-Wasmer-version entries that the runtime then loads and panics on. Mirrors
+        // cmd/nitro/init/init.go:deleteWasmEntries.
         int keyLengthMismatchCount = 0;
+        List<byte[]> toDelete = new();
 
-        foreach (byte[] key in _db.GetAllKeys())
+        foreach (byte[] key in _db.GetAllKeys(ordered: true))
         {
             if (key.Length == 0)
                 continue;
 
-            bool shouldDelete = false;
             foreach (ReadOnlyMemory<byte> prefix in prefixes)
             {
                 if (key.Length < prefix.Length)
                     continue;
 
-                if (key.AsSpan(0, prefix.Length).SequenceEqual(prefix.Span))
-                {
-                    if (expectedKeyLength.HasValue && key.Length != expectedKeyLength.Value)
-                    {
-                        keyLengthMismatchCount++;
-                        continue;
-                    }
+                if (!key.AsSpan(0, prefix.Length).SequenceEqual(prefix.Span))
+                    continue;
 
-                    shouldDelete = true;
-                    break;
-                }
-            }
-
-            if (shouldDelete)
-            {
-                _db.Remove(key);
-                deletedCount++;
+                if (expectedKeyLength.HasValue && key.Length != expectedKeyLength.Value)
+                    keyLengthMismatchCount++;
+                else
+                    toDelete.Add(key);
+                break;
             }
         }
+
+        foreach (byte[] key in toDelete)
+            _db.Remove(key);
 
         // Clear all cache shards after deletion to maintain consistency
         // Parallel clear pattern from TxPool.AccountCache
-        if (deletedCount > 0)
-        {
+        if (toDelete.Count > 0)
             Parallel.For(0, CacheShardCount, i => _activatedCodeCaches[i].Clear());
-        }
 
-        return new DeleteWasmResult(deletedCount, keyLengthMismatchCount);
+        return new DeleteWasmResult(toDelete.Count, keyLengthMismatchCount);
     }
-
     public byte[]? Get(ReadOnlySpan<byte> key) => _db[key.ToArray()];
 
     public void Set(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value) => _db[key.ToArray()] = value.ToArray();

--- a/src/Nethermind.Arbitrum/Stylus/WasmStoreSchema.cs
+++ b/src/Nethermind.Arbitrum/Stylus/WasmStoreSchema.cs
@@ -9,8 +9,8 @@ public static class WasmStoreSchema
 {
     public const byte WasmSchemaVersion = 1;
 
-    // Based on https://github.com/wasmerio/wasmer/blob/6de934035a4b34c2878552320f058862faea4651/lib/types/src/serialize.rs#L16
-    public const byte WasmerSerializeVersion = 8;
+    // Based on https://github.com/OffchainLabs/nitro/blob/v3.10.0-rc.6/cmd/nitro/init/init.go#L64
+    public const byte WasmerSerializeVersion = 16;
 
     public static readonly ReadOnlyMemory<byte> WasmSchemaVersionKey = "WasmSchemaVersion"u8.ToArray();
     public static readonly ReadOnlyMemory<byte> WasmerSerializeVersionKey = "WasmerSerializeVersion"u8.ToArray();


### PR DESCRIPTION
This PR fixes several issues:

### Wasmer serialize version

Follows https://github.com/OffchainLabs/nitro/blob/v3.10.0-rc.6/cmd/nitro/init/init.go#L64

Native code of existing stylus contracts needs to be rebuilt to be supported in a newer Wasmer. Otherwise we'll get the following error during blocks reprocessing
```
  25 Apr 14:32:11 | Rerunning block after reorg or pruning: 455647286 (0xb14040...360260)
  25 Apr 14:32:11 | Rerunning block after reorg or pruning: 455647287 (0x71bef5...23e53c)
  25 Apr 14:32:11 | Rerunning block after reorg or pruning: 455647288 (0x7fd63b...bd5ae9)

  thread '<unnamed>' (142879) panicked at crates/stylus/src/util.rs:19:5:
  encountered fatal wasm: init failed

  Caused by:
      incompatible binary: The provided bytes were serialized by an incompatible version of Wasmer

  Location:
      crates/stylus/src/cache.rs:122:27
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
  fatal runtime error: failed to initiate panic, error 5, aborting
  Aborted (core dumped)
  make: *** [makefile:143: neth] Error 134
``` 

This change triggers [store.DeleteWasmEntries(prefixes)](https://github.com/NethermindEth/nethermind-arbitrum/blob/5fe8ae6c3a3049b0338210bcf0be51547ee4ce05/src/Nethermind.Arbitrum/Stylus/ArbitrumInitializeWasmDb.cs#L57C41-L57C58) and rebuild after 

<img width="1058" height="624" alt="Screenshot 2026-04-25 at 8 40 44 PM" src="https://github.com/user-attachments/assets/1cb5e41c-a6aa-4e9b-a8e1-71601297aa64" />

### WasmDB migration only after Stylus Native is initialized

`ArbitrumInitializeWasmDb` must be run only after `ArbitrumInitializeStylusNative` step is finished. Otherwise, rebuilding WASMs using `StylusPrograms.SaveActiveProgramForRebuild` from `WasmStoreRebuilder.RebuildWasmStore` will be happenning for the wrong Stylus targets. It will blow up later in runtime.

### ArbitrumInitializeWasmDb must deterministically delete all existing WASMs from WasmDB before upgrading Wasmer serialize version

We use hash-bucketed memtable schema for WasmDB (`memtable=prefix_hash:1000000` config option). It makes tailing iterators provide non-deterministic next entries when the memtable is being mutated during the traversion. That makes `WasmDb.DeleteWasmEntries` miss some of the entries during a clean up. That leaves compiled WASMs of the old Wasmer serialize version in the store. It will blow up the app in the runtime when those entries are read during Stylus execution.

The fix is deletion of records in two phases - collect all keys first, remove after.
