### PR TITLE
Add stats format tests, improve formatting, fix stats

### DIFF
--- a/src/Nethermind.Arbitrum.Test/Processing/ProcessingStatsFormatterTests.cs
+++ b/src/Nethermind.Arbitrum.Test/Processing/ProcessingStatsFormatterTests.cs
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: https://github.com/NethermindEth/nethermind-arbitrum/blob/main/LICENSE.md
+
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using Nethermind.Arbitrum.Processing;
+
+namespace Nethermind.Arbitrum.Test.Processing;
+
+[TestFixture]
+public class ProcessingStatsFormatterTests
+{
+    private static readonly Regex AnsiRegex = new("\u001b\\[[0-9;]*m", RegexOptions.Compiled);
+
+    [Test]
+    public void Format_MultiBlockChunk_MatchesExampleOutput()
+    {
+        ProcessingStatsReport report = new(
+            BlockNumber: 452963255,
+            ChunkBlocks: 128,
+            ChunkMGas: 83.17,
+            ChunkTx: 617,
+            ChunkMs: 316.8,
+            RunMs: -1,
+            GasPrices: (Min: 0.020f, EstMedian: 0.020f, Ave: 0.020f, Max: 0.024f),
+            ChunkCalls: 0,
+            ChunkEmptyCalls: 0,
+            ChunkSload: 0,
+            ChunkSstore: 0,
+            ChunkCreates: 0,
+            ChunkSelfDestructs: 0,
+            ChunkOpCodes: 11652987,
+            MGasPerSecond: 262.54,
+            Txps: 1947.5,
+            Bps: 404.03,
+            GasLimit: 32_000_000,
+            StylusCallsDelta: 0,
+            StylusMs: 0,
+            CachedContractsUsed: 0,
+            ContractsAnalysed: 0,
+            RecoveryQueueSize: 0,
+            ProcessingQueueSize: 0);
+
+        string expected =
+            """
+            Processed  452963128..452963255 |    316.8 ms | elapsed     -1 ms | ⛽ Gas gwei: 0.020 .. 0.020 (0.020) .. 0.024
+             Blocks x128         83.17 MGas |     617 txs | stylus          0 | calls           0 | sload      0 | sstore       0 | create    0
+             Throughput       262.54 MGas/s | 1,947.5 tps |   404.03 blocks/s | code cache      0 | new        0 | ops 11,652,987 | destruct  0
+            """;
+
+        Format(in report).Should().Be(expected);
+    }
+
+    [Test]
+    public void Format_Teragas_MatchesExampleOutput()
+    {
+        ProcessingStatsReport report = new(
+            BlockNumber: 452963255,
+            ChunkBlocks: 128,
+            ChunkMGas: 83.17,
+            ChunkTx: 617,
+            ChunkMs: 316.8,
+            RunMs: -1,
+            GasPrices: (Min: 0.020f, EstMedian: 0.020f, Ave: 0.020f, Max: 0.024f),
+            ChunkCalls: 0,
+            ChunkEmptyCalls: 0,
+            ChunkSload: 0,
+            ChunkSstore: 0,
+            ChunkCreates: 0,
+            ChunkSelfDestructs: 0,
+            ChunkOpCodes: 0,
+            MGasPerSecond: 2000.54,
+            Txps: 1947.5,
+            Bps: 404.03,
+            GasLimit: 32_000_000,
+            StylusCallsDelta: 0,
+            StylusMs: 0,
+            CachedContractsUsed: 0,
+            ContractsAnalysed: 0,
+            RecoveryQueueSize: 0,
+            ProcessingQueueSize: 0);
+
+        string expected =
+            """
+            Processed  452963128..452963255 |    316.8 ms | elapsed     -1 ms | ⛽ Gas gwei: 0.020 .. 0.020 (0.020) .. 0.024
+             Blocks x128         83.17 MGas |     617 txs | stylus          0 | calls           0 | sload      0 | sstore       0 | create    0
+             Throughput    🔥2000.54 MGas/s | 1,947.5 tps |   404.03 blocks/s | code cache      0 | new        0 | ops          0 | destruct  0
+            """;
+
+        Format(in report).Should().Be(expected);
+    }
+
+    [Test]
+    public void Format_SingleBlockChunk_UsesSingularBlockLabel()
+    {
+        ProcessingStatsReport report = new(
+            BlockNumber: 100,
+            ChunkBlocks: 1,
+            ChunkMGas: 5.50,
+            ChunkTx: 50,
+            ChunkMs: 2500.0,
+            RunMs: 1000,
+            GasPrices: (Min: 0.1f, EstMedian: 0.1f, Ave: 0.1f, Max: 0.2f),
+            ChunkCalls: 100,
+            ChunkEmptyCalls: 5,
+            ChunkSload: 200,
+            ChunkSstore: 50,
+            ChunkCreates: 10,
+            ChunkSelfDestructs: 0,
+            ChunkOpCodes: 5000,
+            MGasPerSecond: 22.0,
+            Txps: 200.0,
+            Bps: 4.0,
+            GasLimit: 32_000_000,
+            StylusCallsDelta: 0,
+            StylusMs: 0,
+            CachedContractsUsed: 100,
+            ContractsAnalysed: 5,
+            RecoveryQueueSize: 0,
+            ProcessingQueueSize: 0);
+
+        string expected =
+            """
+            Processed                   100 |  2,500.0 ms | elapsed  1,000 ms | ⛽ Gas gwei: 0.100 .. 0.100 (0.100) .. 0.200
+             Block                5.50 MGas |      50 txs | stylus          0 | calls         100 | sload    200 | sstore      50 | create   10
+             Throughput        22.00 MGas/s |   200.0 tps |     4.00 blocks/s | code cache    100 | new        5 | ops      5,000 | destruct  0
+            """;
+
+        Format(in report).Should().Be(expected);
+    }
+
+    [Test]
+    public void Format_RecoveryOrProcessingQueueActive_UsesAlternateThroughputLine()
+    {
+        ProcessingStatsReport report = new(
+            BlockNumber: 200,
+            ChunkBlocks: 10,
+            ChunkMGas: 10.0,
+            ChunkTx: 100,
+            ChunkMs: 100.0,
+            RunMs: 200,
+            GasPrices: (Min: 0.5f, EstMedian: 0.5f, Ave: 0.5f, Max: 0.5f),
+            ChunkCalls: 0,
+            ChunkEmptyCalls: 0,
+            ChunkSload: 0,
+            ChunkSstore: 0,
+            ChunkCreates: 0,
+            ChunkSelfDestructs: 0,
+            ChunkOpCodes: 1000,
+            MGasPerSecond: 100.0,
+            Txps: 1000.0,
+            Bps: 100.0,
+            GasLimit: 32_000_000,
+            StylusCallsDelta: 3,
+            StylusMs: 0,
+            CachedContractsUsed: 0,
+            ContractsAnalysed: 0,
+            RecoveryQueueSize: 5,
+            ProcessingQueueSize: 3);
+
+        string expected =
+            """
+            Processed        191..      200 |    100.0 ms | elapsed    200 ms | ⛽ Gas gwei: 0.500 .. 0.500 (0.500) .. 0.500
+             Blocks x10          10.00 MGas |     100 txs | stylus          3 | calls           0 | sload      0 | sstore       0 | create    0
+             Throughput       100.00 MGas/s | 1,000.0 tps |   100.00 blocks/s | recover         5 | process    3 | ops      1,000 | destruct  0
+            """;
+
+        Format(in report).Should().Be(expected);
+    }
+
+    [Test]
+    public void Format_SignificantStylusActivity_AddsSplashEmoji()
+    {
+        ProcessingStatsReport report = new(
+            BlockNumber: 1000,
+            ChunkBlocks: 10,
+            ChunkMGas: 5.0,
+            ChunkTx: 50,
+            ChunkMs: 100.0,
+            RunMs: 200,
+            GasPrices: (Min: 0.5f, EstMedian: 0.5f, Ave: 0.5f, Max: 0.5f),
+            ChunkCalls: 12751,
+            ChunkEmptyCalls: 5,
+            ChunkSload: 22621 ,
+            ChunkSstore: 5,
+            ChunkCreates: 2,
+            ChunkSelfDestructs: 0,
+            ChunkOpCodes: 5630090,
+            MGasPerSecond: 50.0,
+            Txps: 500.0,
+            Bps: 100.0,
+            GasLimit: 32_000_000,
+            StylusCallsDelta: 3125,
+            StylusMs: 12.3,
+            CachedContractsUsed: 19716,
+            ContractsAnalysed: 0,
+            RecoveryQueueSize: 0,
+            ProcessingQueueSize: 0);
+
+        string expected =
+            """
+            Processed        991..     1000 |    100.0 ms | elapsed    200 ms | ⛽ Gas gwei: 0.500 .. 0.500 (0.500) .. 0.500
+             Blocks x10           5.00 MGas |      50 txs | stylus    ✨3,125 | calls      12,751 | sload 22,621 | sstore       5 | create    2
+             Throughput        50.00 MGas/s |   500.0 tps |   100.00 blocks/s | code cache 19,716 | new        0 | ops  5,630,090 | destruct  0
+            """;
+
+        Format(in report).Should().Be(expected);
+    }
+
+    [Test]
+    public void Format_NullGasPrices_OmitsGasSegment()
+    {
+        ProcessingStatsReport report = new(
+            BlockNumber: 50,
+            ChunkBlocks: 1,
+            ChunkMGas: 1.0,
+            ChunkTx: 1,
+            ChunkMs: 100.0,
+            RunMs: 100,
+            GasPrices: null,
+            ChunkCalls: 0,
+            ChunkEmptyCalls: 0,
+            ChunkSload: 0,
+            ChunkSstore: 0,
+            ChunkCreates: 33,
+            ChunkSelfDestructs: 20,
+            ChunkOpCodes: 0,
+            MGasPerSecond: 10.0,
+            Txps: 10.0,
+            Bps: 10.0,
+            GasLimit: 32_000_000,
+            StylusCallsDelta: 0,
+            StylusMs: 0,
+            CachedContractsUsed: 0,
+            ContractsAnalysed: 0,
+            RecoveryQueueSize: 0,
+            ProcessingQueueSize: 0);
+
+        // Trailing space on line 1 (`| `) is significant — the empty gas segment leaves it dangling.
+        // Use interpolation in a raw string so editor trim_trailing_whitespace cannot silently break the test.
+        string expected =
+            $$"""
+            Processed                    50 |    100.0 ms | elapsed    100 ms |{{" "}}
+             Block                1.00 MGas |       1 txs | stylus          0 | calls           0 | sload      0 | sstore       0 | create   33
+             Throughput        10.00 MGas/s |    10.0 tps |    10.00 blocks/s | code cache      0 | new        0 | ops          0 | destruct 20
+            """;
+
+        Format(in report).Should().Be(expected);
+    }
+
+    private static string Format(in ProcessingStatsReport report)
+    {
+        List<string> lines = new();
+        ProcessingStatsFormatter.Format(in report, lines);
+        return string.Join('\n', lines.Select(l => AnsiRegex.Replace(l, "")));
+    }
+}

--- a/src/Nethermind.Arbitrum.Test/Processing/ProcessingStatsFormatterTests.cs
+++ b/src/Nethermind.Arbitrum.Test/Processing/ProcessingStatsFormatterTests.cs
@@ -181,7 +181,7 @@ public class ProcessingStatsFormatterTests
             GasPrices: (Min: 0.5f, EstMedian: 0.5f, Ave: 0.5f, Max: 0.5f),
             ChunkCalls: 12751,
             ChunkEmptyCalls: 5,
-            ChunkSload: 22621 ,
+            ChunkSload: 22621,
             ChunkSstore: 5,
             ChunkCreates: 2,
             ChunkSelfDestructs: 0,

--- a/src/Nethermind.Arbitrum/Execution/ArbitrumBlockFactory.cs
+++ b/src/Nethermind.Arbitrum/Execution/ArbitrumBlockFactory.cs
@@ -13,6 +13,7 @@ using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Producers;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Threading;
 using Nethermind.JsonRpc;
 using Nethermind.Logging;
 
@@ -175,6 +176,9 @@ public sealed class ArbitrumBlockFactory(
 
     private async Task<ResultWrapper<Block>> ProduceBlockWithoutWaitingOnProcessingQueueAsync(ArbitrumPayloadAttributes payload, BlockHeader? parentHeader)
     {
+        bool previousMainThread = ProcessingThread.IsBlockProcessingThread;
+        ProcessingThread.IsBlockProcessingThread = true;
+
         try
         {
             Block? block = await trigger.BuildBlock(parentHeader: parentHeader, payloadAttributes: payload);
@@ -187,16 +191,30 @@ public sealed class ArbitrumBlockFactory(
         {
             return ResultWrapper<Block>.Fail("Timeout waiting for block processing result.", ErrorCodes.Timeout);
         }
+        finally
+        {
+            ProcessingThread.IsBlockProcessingThread = previousMainThread;
+        }
     }
 
     private async Task<ResultWrapper<Block>> ProduceBlockWhileLockedAsync(ArbitrumPayloadAttributes payload, BlockHeader? parentHeader)
     {
         return await WaitForBlockProcessingAsync(async () =>
         {
-            Block? block = await trigger.BuildBlock(parentHeader: parentHeader, payloadAttributes: payload);
-            return block?.Hash is null
-                ? ResultWrapper<Block>.Fail("Failed to build block or block has no hash.", ErrorCodes.InternalError)
-                : ResultWrapper<Block>.Success(block);
+            bool previousMainThread = ProcessingThread.IsBlockProcessingThread;
+            ProcessingThread.IsBlockProcessingThread = true;
+
+            try
+            {
+                Block? block = await trigger.BuildBlock(parentHeader: parentHeader, payloadAttributes: payload);
+                return block?.Hash is null
+                    ? ResultWrapper<Block>.Fail("Failed to build block or block has no hash.", ErrorCodes.InternalError)
+                    : ResultWrapper<Block>.Success(block);
+            }
+            finally
+            {
+                ProcessingThread.IsBlockProcessingThread = previousMainThread;
+            }
         });
     }
 

--- a/src/Nethermind.Arbitrum/Execution/ArbitrumBlockProcessor.cs
+++ b/src/Nethermind.Arbitrum/Execution/ArbitrumBlockProcessor.cs
@@ -43,6 +43,7 @@ namespace Nethermind.Arbitrum.Execution
     {
         private readonly CachedL1PriceData _cachedL1PriceData;
         private readonly IWasmStore _wasmStore;
+        private readonly IProcessingStats _stats;
 
         public ArbitrumBlockProcessor(
             ISpecProvider specProvider,
@@ -60,6 +61,7 @@ namespace Nethermind.Arbitrum.Execution
             IWithdrawalProcessor withdrawalProcessor,
             IExecutionRequestsProcessor executionRequestsProcessor,
             IBlockAccessListManager balManager,
+            IProcessingStats stats,
             IArbitrumConfig arbitrumConfig)
             : base(
                 specProvider,
@@ -77,6 +79,7 @@ namespace Nethermind.Arbitrum.Execution
         {
             _cachedL1PriceData = cachedL1PriceData;
             _wasmStore = wasmStore;
+            _stats = stats;
             ReceiptsTracer = new ArbitrumBlockReceiptTracer((txProcessor as ArbitrumTransactionProcessor)!.TxExecContext, arbitrumConfig);
         }
 
@@ -88,6 +91,7 @@ namespace Nethermind.Arbitrum.Execution
             CancellationToken token)
         {
             _wasmStore.GetRecentWasms().Clear();
+            _stats.Start();
 
             TxReceipt[] receipts = base.ProcessBlock(block, blockTracer, options, releaseSpec, token);
             _cachedL1PriceData.CacheL1PriceDataOfMsg(

--- a/src/Nethermind.Arbitrum/Processing/ArbitrumProcessingStats.cs
+++ b/src/Nethermind.Arbitrum/Processing/ArbitrumProcessingStats.cs
@@ -63,20 +63,8 @@ public class ArbitrumProcessingStats : IProcessingStats
     private long _lastStylusCalls;
     private long _lastStylusExecutionMicroseconds;
 
-    // ANSI color codes
-    private const string ResetColor = "\u001b[37m";
-    private const string WhiteText = "\u001b[97m";
-    private const string YellowText = "\u001b[93m";
-    private const string OrangeText = "\u001b[38;5;208m";
-    private const string RedText = "\u001b[38;5;196m";
-    private const string GreenText = "\u001b[92m";
-    private const string DarkGreenText = "\u001b[32m";
-    private const string DarkCyanText = "\u001b[36m";
-    private const string BlueText = "\u001b[94m";
-    private const string MagentaText = "\u001b[95m";
-
-    // Threshold for showing splash emoji (stylus calls > 20% of total EVM calls)
-    private const double StylusSignificanceThreshold = 0.2;
+    // Reused buffer for formatter output to avoid per-report allocations.
+    private readonly List<string> _formatterLines = new(3);
 
     public ArbitrumProcessingStats(IStateReader stateReader, ILogManager logManager)
     {
@@ -149,9 +137,7 @@ public class ArbitrumProcessingStats : IProcessingStats
         try
         {
             lock (_reportLock)
-            {
                 GenerateReport(data);
-            }
         }
         catch (Exception ex)
         {
@@ -208,16 +194,12 @@ public class ArbitrumProcessingStats : IProcessingStats
         // Skip logging during init/genesis when state isn't fully available
         if (data.BaseBlock is null || !_stateReader.HasStateForBlock(data.BaseBlock) ||
             block.StateRoot is null || !_stateReader.HasStateForBlock(block.Header))
-        {
             return;
-        }
 
         // Throttle logging to once per second (or always in debug mode)
         long reportMs = Environment.TickCount64;
         if (reportMs - _lastReportMs <= 1000 && !_logger.IsDebug)
-        {
             return;
-        }
         _lastReportMs = reportMs;
 
         // Capture Stylus metrics before resetting
@@ -248,9 +230,7 @@ public class ArbitrumProcessingStats : IProcessingStats
         // Calculate throughput metrics
         double mgasPerSecond = chunkMicroseconds == 0 ? -1 : chunkMGas / chunkMicroseconds * 1_000_000.0;
         if (chunkMicroseconds != 0 && chunkMGas != 0)
-        {
             BlockchainMetrics.MgasPerSec = mgasPerSecond;
-        }
 
         double txps = chunkMicroseconds == 0 ? -1 : chunkTx / chunkMicroseconds * 1_000_000.0;
         double bps = chunkMicroseconds == 0 ? -1 : chunkBlocks / chunkMicroseconds * 1_000_000.0;
@@ -281,92 +261,43 @@ public class ArbitrumProcessingStats : IProcessingStats
         if (!_logger.IsInfo)
             return;
 
-        string gasPrice = gasPrices is { } g
-            ? $"⛽ Gas gwei: {g.Min:N3} .. {WhiteText}{System.Math.Max(g.Min, g.EstMedian):N3}{ResetColor} ({g.Ave:N3}) .. {g.Max:N3}"
-            : "";
+        ProcessingStatsReport report = new(
+            BlockNumber: blockNumber,
+            ChunkBlocks: chunkBlocks,
+            ChunkMGas: chunkMGas,
+            ChunkTx: (long)chunkTx,
+            ChunkMs: chunkMs,
+            RunMs: runMs,
+            GasPrices: gasPrices,
+            ChunkCalls: chunkCalls,
+            ChunkEmptyCalls: chunkEmptyCalls,
+            ChunkSload: chunkSload,
+            ChunkSstore: chunkSstore,
+            ChunkCreates: chunkCreates,
+            ChunkSelfDestructs: chunkSelfDestructs,
+            ChunkOpCodes: chunkOpCodes,
+            MGasPerSecond: mgasPerSecond,
+            Txps: txps,
+            Bps: bps,
+            GasLimit: block.GasLimit,
+            StylusCallsDelta: stylusCallsDelta,
+            StylusMs: stylusCallsDelta > 0 ? stylusMicrosDelta / 1000.0 : 0,
+            CachedContractsUsed: cachedContractsUsed,
+            ContractsAnalysed: contractsAnalysed,
+            RecoveryQueueSize: BlockchainMetrics.RecoveryQueueSize,
+            ProcessingQueueSize: BlockchainMetrics.ProcessingQueueSize);
 
-        if (chunkBlocks > 1)
-        {
-            _logger.Info($"Processed    {block.Number - chunkBlocks + 1,10}...{block.Number,9}   | {chunkMs,10:N1} ms  | elapsed {runMs,15:N0} ms | {gasPrice}");
-        }
-        else
-        {
-            string chunkColor = chunkMs switch
-            {
-                < 200 => GreenText,
-                < 300 => DarkGreenText,
-                < 500 => WhiteText,
-                < 1000 => YellowText,
-                < 2000 => OrangeText,
-                _ => RedText
-            };
-            _logger.Info($"Processed          {block.Number,10}         | {chunkColor}{chunkMs,10:N1}{ResetColor} ms  | elapsed {runMs,15:N0} ms | {gasPrice}");
-        }
+        _formatterLines.Clear();
 
-        // Log block details
-        string mgasPerSecondColor = (mgasPerSecond / (block.GasLimit / 1_000_000.0)) switch
-        {
-            > 3 => GreenText,
-            > 2.5f => DarkGreenText,
-            > 2 => WhiteText,
-            > 1.5f => ResetColor,
-            > 1 => YellowText,
-            > 0.5f => OrangeText,
-            _ => RedText
-        };
-        string sstoreColor = chunkBlocks > 1 ? "" : chunkSstore switch
-        {
-            > 3500 => RedText,
-            > 2500 => OrangeText,
-            > 2000 => YellowText,
-            > 1500 => WhiteText,
-            > 900 when chunkCalls > 900 => WhiteText,
-            _ => ""
-        };
-        string callsColor = chunkBlocks > 1 ? "" : chunkCalls switch
-        {
-            > 3500 => RedText,
-            > 2500 => OrangeText,
-            > 2000 => YellowText,
-            > 1500 => WhiteText,
-            > 900 when chunkSstore > 900 => WhiteText,
-            _ => ""
-        };
-        string createsColor = chunkBlocks > 1 ? "" : chunkCreates switch
-        {
-            > 300 => RedText,
-            > 200 => OrangeText,
-            > 150 => YellowText,
-            > 75 => WhiteText,
-            _ => ""
-        };
+        ProcessingStatsFormatter.Format(in report, _formatterLines);
 
-        // Build Stylus section for Block line
-        double stylusMs = stylusCallsDelta > 0 ? stylusMicrosDelta / 1000.0 : 0;
-        bool isSignificant = stylusCallsDelta > 0 && (chunkCalls == 0 || stylusCallsDelta > chunkCalls * StylusSignificanceThreshold);
-        string splash = isSignificant ? " 🌊" : "   "; // space+emoji OR 3 spaces for alignment
-        string stylusSection = $" | {MagentaText}🦀 stylus {stylusCallsDelta,3:N0}{ResetColor} ({stylusMs,5:F1}ms){splash}";
-
-        _logger.Info($" Block{(chunkBlocks > 1 ? $"s  x{chunkBlocks,-9:N0} " : "              ")}{(chunkBlocks == 1 ? (chunkMGas / (block.GasLimit / 16_000_000.0)) switch { > 15 => RedText, > 14 => OrangeText, > 13 => YellowText, > 10 => DarkGreenText, > 7 => GreenText, > 6 => DarkGreenText, > 5 => WhiteText, > 4 => ResetColor, > 3 => DarkCyanText, _ => BlueText } : "")} {chunkMGas,8:F2}{ResetColor} MGas    | {chunkTx,8:N0}   txs{stylusSection} | calls {callsColor}{chunkCalls,10:N0}{ResetColor} ({chunkEmptyCalls,3:N0}) | sload {chunkSload,7:N0} | sstore {sstoreColor}{chunkSstore,6:N0}{ResetColor} | create {createsColor}{chunkCreates,3:N0}{ResetColor}{(chunkSelfDestructs > 0 ? $"({-chunkSelfDestructs,3:N0})" : "")}");
-
-        // Log throughput
-        long recoveryQueue = BlockchainMetrics.RecoveryQueueSize;
-        long processingQueue = BlockchainMetrics.ProcessingQueueSize;
-        string blocksPerSec = $"       {bps,14:F2} Blk/s ";
-
-        if (recoveryQueue > 0 || processingQueue > 0)
-        {
-            _logger.Info($" Block throughput {mgasPerSecondColor}{mgasPerSecond,11:F2}{ResetColor} MGas/s{(mgasPerSecond > 1000 ? "🔥" : "  ")}| {txps,10:N1} tps |{blocksPerSec}| recover {recoveryQueue,5:N0} | process {processingQueue,5:N0} | ops {chunkOpCodes,9:N0}");
-        }
-        else
-        {
-            _logger.Info($" Block throughput {mgasPerSecondColor}{mgasPerSecond,11:F2}{ResetColor} MGas/s{(mgasPerSecond > 1000 ? "🔥" : "  ")}| {txps,10:N1} tps |{blocksPerSec}| exec code{ResetColor} cache {cachedContractsUsed,6:N0} |{ResetColor} new {contractsAnalysed,9:N0} | ops {chunkOpCodes,9:N0}");
-        }
+        foreach (string line in _formatterLines)
+            _logger.Info(line);
     }
 
     private class BlockDataPolicy : IPooledObjectPolicy<BlockData>
     {
-        public BlockData Create() => new BlockData();
+        public BlockData Create() => new();
         public bool Return(BlockData data)
         {
             data.Block = null;

--- a/src/Nethermind.Arbitrum/Processing/ProcessingStatsFormatter.cs
+++ b/src/Nethermind.Arbitrum/Processing/ProcessingStatsFormatter.cs
@@ -94,7 +94,7 @@ internal static class ProcessingStatsFormatter
         string splash = isSignificant ? " ✨" : "   ";
         string stylusSection = $" | {MagentaText}stylus {GetGap(7, report.StylusCallsDelta)}{splash}{report.StylusCallsDelta:N0}{ResetColor}";
 
-        lines.Add($" Block{(report.ChunkBlocks > 1 ? $"s x{report.ChunkBlocks,-3:N0} " : "       ")} {mgasColor}{report.ChunkMGas,12:F2}{ResetColor} MGas | {report.ChunkTx,7:N0} txs{stylusSection} | calls {callsColor}{report.ChunkCalls,11:N0}{ResetColor} | sload {report.ChunkSload,6 :N0} | sstore {sstoreColor}{report.ChunkSstore,7:N0}{ResetColor} | create {createsColor}{report.ChunkCreates,4:N0}{ResetColor}");
+        lines.Add($" Block{(report.ChunkBlocks > 1 ? $"s x{report.ChunkBlocks,-3:N0} " : "       ")} {mgasColor}{report.ChunkMGas,12:F2}{ResetColor} MGas | {report.ChunkTx,7:N0} txs{stylusSection} | calls {callsColor}{report.ChunkCalls,11:N0}{ResetColor} | sload {report.ChunkSload,6:N0} | sstore {sstoreColor}{report.ChunkSstore,7:N0}{ResetColor} | create {createsColor}{report.ChunkCreates,4:N0}{ResetColor}");
 
         if (report.RecoveryQueueSize > 0 || report.ProcessingQueueSize > 0)
             lines.Add($" Throughput    {(report.MGasPerSecond > 1000 ? "🔥" : "  ")}{mgasPerSecondColor}{report.MGasPerSecond,7:F2}{ResetColor} MGas/s | {report.Txps,7:N1} tps " +

--- a/src/Nethermind.Arbitrum/Processing/ProcessingStatsFormatter.cs
+++ b/src/Nethermind.Arbitrum/Processing/ProcessingStatsFormatter.cs
@@ -108,7 +108,7 @@ internal static class ProcessingStatsFormatter
     {
         int digits = n == 0 ? 1 : (int)System.Math.Floor(System.Math.Log10(System.Math.Abs(n))) + 1;
         int length = digits + (digits - 1) / 3 + (n < 0 ? 1 : 0);
-        return new string(' ', gapMaxLength - length);
+        return new string(' ', System.Math.Max(0, gapMaxLength - length));
     }
 }
 

--- a/src/Nethermind.Arbitrum/Processing/ProcessingStatsFormatter.cs
+++ b/src/Nethermind.Arbitrum/Processing/ProcessingStatsFormatter.cs
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: https://github.com/NethermindEth/nethermind-arbitrum/blob/main/LICENSE.md
+
+namespace Nethermind.Arbitrum.Processing;
+
+internal static class ProcessingStatsFormatter
+{
+    private const string ResetColor = "\u001b[37m";
+    private const string WhiteText = "\u001b[97m";
+    private const string YellowText = "\u001b[93m";
+    private const string OrangeText = "\u001b[38;5;208m";
+    private const string RedText = "\u001b[38;5;196m";
+    private const string GreenText = "\u001b[92m";
+    private const string DarkGreenText = "\u001b[32m";
+    private const string DarkCyanText = "\u001b[36m";
+    private const string BlueText = "\u001b[94m";
+    private const string MagentaText = "\u001b[95m";
+
+    private const double StylusSignificanceThreshold = 0.2;
+
+    public static void Format(scoped in ProcessingStatsReport report, List<string> lines)
+    {
+        string gasPrice = report.GasPrices is { } g
+            ? $"⛽ Gas gwei: {g.Min:N3} .. {WhiteText}{System.Math.Max(g.Min, g.EstMedian):N3}{ResetColor} ({g.Ave:N3}) .. {g.Max:N3}"
+            : "";
+
+        if (report.ChunkBlocks > 1)
+            lines.Add($"Processed  {report.BlockNumber - report.ChunkBlocks + 1,9}..{report.BlockNumber,9} | {report.ChunkMs,8:N1} ms | elapsed {report.RunMs,6:N0} ms | {gasPrice}");
+        else
+        {
+            string chunkColor = report.ChunkMs switch
+            {
+                < 200 => GreenText,
+                < 300 => DarkGreenText,
+                < 500 => WhiteText,
+                < 1000 => YellowText,
+                < 2000 => OrangeText,
+                _ => RedText
+            };
+            lines.Add($"Processed             {report.BlockNumber,9} | {chunkColor}{report.ChunkMs,8:N1}{ResetColor} ms | elapsed {report.RunMs,6:N0} ms | {gasPrice}");
+        }
+
+        string mgasPerSecondColor = (report.MGasPerSecond / (report.GasLimit / 1_000_000.0)) switch
+        {
+            > 3 => GreenText,
+            > 2.5f => DarkGreenText,
+            > 2 => WhiteText,
+            > 1.5f => ResetColor,
+            > 1 => YellowText,
+            > 0.5f => OrangeText,
+            _ => RedText
+        };
+        string sstoreColor = report.ChunkBlocks > 1 ? "" : report.ChunkSstore switch
+        {
+            > 3500 => RedText,
+            > 2500 => OrangeText,
+            > 2000 => YellowText,
+            > 1500 => WhiteText,
+            > 900 when report.ChunkCalls > 900 => WhiteText,
+            _ => ""
+        };
+        string callsColor = report.ChunkBlocks > 1 ? "" : report.ChunkCalls switch
+        {
+            > 3500 => RedText,
+            > 2500 => OrangeText,
+            > 2000 => YellowText,
+            > 1500 => WhiteText,
+            > 900 when report.ChunkSstore > 900 => WhiteText,
+            _ => ""
+        };
+        string createsColor = report.ChunkBlocks > 1 ? "" : report.ChunkCreates switch
+        {
+            > 300 => RedText,
+            > 200 => OrangeText,
+            > 150 => YellowText,
+            > 75 => WhiteText,
+            _ => ""
+        };
+        string mgasColor = report.ChunkBlocks != 1 ? "" : (report.ChunkMGas / (report.GasLimit / 16_000_000.0)) switch
+        {
+            > 15 => RedText,
+            > 14 => OrangeText,
+            > 13 => YellowText,
+            > 10 => DarkGreenText,
+            > 7 => GreenText,
+            > 6 => DarkGreenText,
+            > 5 => WhiteText,
+            > 4 => ResetColor,
+            > 3 => DarkCyanText,
+            _ => BlueText
+        };
+
+        bool isSignificant = report.StylusCallsDelta > 10 && (report.ChunkCalls == 0 || report.StylusCallsDelta > report.ChunkCalls * StylusSignificanceThreshold);
+        string splash = isSignificant ? " ✨" : "   ";
+        string stylusSection = $" | {MagentaText}stylus {GetGap(7, report.StylusCallsDelta)}{splash}{report.StylusCallsDelta:N0}{ResetColor}";
+
+        lines.Add($" Block{(report.ChunkBlocks > 1 ? $"s x{report.ChunkBlocks,-3:N0} " : "       ")} {mgasColor}{report.ChunkMGas,12:F2}{ResetColor} MGas | {report.ChunkTx,7:N0} txs{stylusSection} | calls {callsColor}{report.ChunkCalls,11:N0}{ResetColor} | sload {report.ChunkSload,6 :N0} | sstore {sstoreColor}{report.ChunkSstore,7:N0}{ResetColor} | create {createsColor}{report.ChunkCreates,4:N0}{ResetColor}");
+
+        if (report.RecoveryQueueSize > 0 || report.ProcessingQueueSize > 0)
+            lines.Add($" Throughput    {(report.MGasPerSecond > 1000 ? "🔥" : "  ")}{mgasPerSecondColor}{report.MGasPerSecond,7:F2}{ResetColor} MGas/s | {report.Txps,7:N1} tps " +
+                      $"|   {report.Bps,6:F2} blocks/s | recover {report.RecoveryQueueSize,9:N0} | process {report.ProcessingQueueSize,4:N0} | ops {report.ChunkOpCodes,10:N0} | destruct {report.ChunkSelfDestructs,2:N0}");
+        else
+            lines.Add($" Throughput    {(report.MGasPerSecond > 1000 ? "🔥" : "  ")}{mgasPerSecondColor}{report.MGasPerSecond,7:F2}{ResetColor} MGas/s | {report.Txps,7:N1} tps " +
+                      $"|   {report.Bps,6:F2} blocks/s | code cache {report.CachedContractsUsed,6:N0} | new {report.ContractsAnalysed,8:N0} | ops {report.ChunkOpCodes,10:N0} | destruct {report.ChunkSelfDestructs,2:N0}");
+    }
+
+    private static string GetGap(int gapMaxLength, long n)
+    {
+        int digits = n == 0 ? 1 : (int)System.Math.Floor(System.Math.Log10(System.Math.Abs(n))) + 1;
+        int length = digits + (digits - 1) / 3 + (n < 0 ? 1 : 0);
+        return new string(' ', gapMaxLength - length);
+    }
+}
+
+internal readonly record struct ProcessingStatsReport(
+    long BlockNumber,
+    long ChunkBlocks,
+    double ChunkMGas,
+    long ChunkTx,
+    double ChunkMs,
+    double RunMs,
+    (float Min, float EstMedian, float Ave, float Max)? GasPrices,
+    long ChunkCalls,
+    long ChunkEmptyCalls,
+    long ChunkSload,
+    long ChunkSstore,
+    long ChunkCreates,
+    long ChunkSelfDestructs,
+    long ChunkOpCodes,
+    double MGasPerSecond,
+    double Txps,
+    double Bps,
+    long GasLimit,
+    long StylusCallsDelta,
+    double StylusMs,
+    long CachedContractsUsed,
+    long ContractsAnalysed,
+    long RecoveryQueueSize,
+    long ProcessingQueueSize);


### PR DESCRIPTION
Fixes stats outputs as previously we've been reporting zeroes:

<img width="1212" height="150" alt="Screenshot 2026-04-29 at 3 32 51 PM" src="https://github.com/user-attachments/assets/bfd9dc72-0c11-4671-b44e-bc2cb7feb7c7" />

Updates stats output to take less space

<img width="1051" height="196" alt="Screenshot 2026-04-29 at 3 24 35 PM" src="https://github.com/user-attachments/assets/9e6a004a-c8c2-4553-86b1-e19cd764eb62" />

<img width="1055" height="193" alt="Screenshot 2026-04-29 at 3 24 16 PM" src="https://github.com/user-attachments/assets/6efe0f00-77bf-4a56-a11d-ca4931653fb0" />
