### PR TITLE
Change default pruning settings

### DIFF
--- a/src/Nethermind.Arbitrum/Properties/configs/arbitrum-local-sequencer.json
+++ b/src/Nethermind.Arbitrum/Properties/configs/arbitrum-local-sequencer.json
@@ -61,7 +61,10 @@
     "RpcRecorderState": "None"
   },
   "Pruning": {
-    "PruningBoundary": 192
+    "PruningBoundary": 192,
+    "MaxUnpersistedBlockCount": 5000,
+    "MinUnpersistedBlockCount": 2000,
+    "MaxBufferedCommitCount": 5000
   },
   "Blocks": {
     "SecondsPerSlot": 2,

--- a/src/Nethermind.Arbitrum/Properties/configs/arbitrum-local.json
+++ b/src/Nethermind.Arbitrum/Properties/configs/arbitrum-local.json
@@ -24,7 +24,7 @@
     "Port": 20545,
     "EnginePort": 20551,
     "UnsecureDevNoRpcAuthentication": true,
-    "EngineEnabledModules": ["Net", "Eth", "Subscribe", "Web3", "Arbitrum", "nitroexecution"],
+    "EngineEnabledModules": [ "Net", "Eth", "Subscribe", "Web3", "Arbitrum", "nitroexecution" ],
     "AdditionalRpcUrls": [
       "http://localhost:28551|http;ws|net;eth;subscribe;web3;client;debug"
     ],
@@ -53,7 +53,10 @@
     ]
   },
   "Pruning": {
-    "PruningBoundary": 192
+    "PruningBoundary": 192,
+    "MaxUnpersistedBlockCount": 5000,
+    "MinUnpersistedBlockCount": 2000,
+    "MaxBufferedCommitCount": 5000
   },
   "Blocks": {
     "SecondsPerSlot": 2,

--- a/src/Nethermind.Arbitrum/Properties/configs/arbitrum-mainnet-archive.json
+++ b/src/Nethermind.Arbitrum/Properties/configs/arbitrum-mainnet-archive.json
@@ -42,10 +42,7 @@
     ]
   },
   "Pruning": {
-    "Mode": "None",
-    "MaxUnpersistedBlockCount": 2500,
-    "MinUnpersistedBlockCount": 72,
-    "MaxBufferedCommitCount": 2500
+    "Mode": "None"
   },
   "Blocks": {
     "PreWarmStateOnBlockProcessing": false,

--- a/src/Nethermind.Arbitrum/Properties/configs/arbitrum-mainnet-with-validation.json
+++ b/src/Nethermind.Arbitrum/Properties/configs/arbitrum-mainnet-with-validation.json
@@ -67,7 +67,7 @@
     "Enabled": true
   },
   "Snapshot": {
-    "Enabled": true,
+    "Enabled": false,
     "SnapshotDirectory": "snapshot/mainnet",
     "DownloadUrl": "https://arb-snapshot.nethermind.dev/arbitrum-snapshot/451380230-neth.tar.zst",
     "SnapshotFileName": "snapshot.tar.zst",

--- a/src/Nethermind.Arbitrum/Properties/configs/arbitrum-mainnet-with-validation.json
+++ b/src/Nethermind.Arbitrum/Properties/configs/arbitrum-mainnet-with-validation.json
@@ -69,7 +69,9 @@
   "Snapshot": {
     "Enabled": true,
     "SnapshotDirectory": "snapshot/mainnet",
-    "DownloadUrl": "https://arb-snapshot.nethermind.dev/arbitrum-snapshot/snapshot.zip"
+    "DownloadUrl": "https://arb-snapshot.nethermind.dev/arbitrum-snapshot/451380230-neth.tar.zst",
+    "SnapshotFileName": "snapshot.tar.zst",
+    "StripComponents": 3
   },
   "Arbitrum": {
     "BlockProcessingTimeout": 10000,

--- a/src/Nethermind.Arbitrum/Properties/configs/arbitrum-mainnet.json
+++ b/src/Nethermind.Arbitrum/Properties/configs/arbitrum-mainnet.json
@@ -72,9 +72,11 @@
     "Enabled": true
   },
   "Snapshot": {
-    "Enabled": true,
+    "Enabled": false,
     "SnapshotDirectory": "snapshot/mainnet",
-    "DownloadUrl": "https://arb-snapshot.nethermind.dev/arbitrum-snapshot/snapshot.zip"
+    "DownloadUrl": "https://arb-snapshot.nethermind.dev/arbitrum-snapshot/451380230-neth.tar.zst",
+    "SnapshotFileName": "snapshot.tar.zst",
+    "StripComponents": 3
   },
   "Arbitrum": {
     "BlockProcessingTimeout": 10000,

--- a/src/Nethermind.Arbitrum/Properties/configs/arbitrum-mainnet.json
+++ b/src/Nethermind.Arbitrum/Properties/configs/arbitrum-mainnet.json
@@ -50,7 +50,10 @@
     ]
   },
   "Pruning": {
-    "PruningBoundary": 192
+    "PruningBoundary": 192,
+    "MaxUnpersistedBlockCount": 5000,
+    "MinUnpersistedBlockCount": 2000,
+    "MaxBufferedCommitCount": 5000
   },
   "History": {
     "Pruning": "Rolling",

--- a/src/Nethermind.Arbitrum/Properties/configs/arbitrum-sepolia-archive.json
+++ b/src/Nethermind.Arbitrum/Properties/configs/arbitrum-sepolia-archive.json
@@ -42,10 +42,7 @@
     ]
   },
   "Pruning": {
-    "Mode": "None",
-    "MaxUnpersistedBlockCount": 2500,
-    "MinUnpersistedBlockCount": 72,
-    "MaxBufferedCommitCount": 2500
+    "Mode": "None"
   },
   "Blocks": {
     "PreWarmStateOnBlockProcessing": false,

--- a/src/Nethermind.Arbitrum/Properties/configs/arbitrum-sepolia.json
+++ b/src/Nethermind.Arbitrum/Properties/configs/arbitrum-sepolia.json
@@ -50,7 +50,10 @@
     ]
   },
   "Pruning": {
-    "PruningBoundary": 192
+    "PruningBoundary": 192,
+    "MaxUnpersistedBlockCount": 5000,
+    "MinUnpersistedBlockCount": 2000,
+    "MaxBufferedCommitCount": 5000
   },
   "History": {
     "Pruning": "Rolling",


### PR DESCRIPTION
We have been testing and proved settings for memory pruning which work better with arbitrum chain specific block time. This change updates these values to default config.
Also updates Arbitrum mainnet snapshot to point to latest snapshot and tested configuration. Snapshot functionality disabled by default to not break existing nodes, which have not been initalised via snapshot.

Summary:
- new default values for memory pruning
- updated mainnet snapshot config