### PR TITLE
fix(build): port release/0.1.2 build-script fixes to release/0.2.0

### DIFF
--- a/scripts/build/build.sh
+++ b/scripts/build/build.sh
@@ -40,17 +40,20 @@ for rid in "linux-arm64" "linux-x64" "osx-arm64" "win-x64"; do
   cp $output_path/$rid/arbitrum-tmp/Nethermind.Arbitrum.* $output_path/$rid/plugins/
 
   # Copy Stylus native libraries from NuGet package output.
-  mkdir -p $output_path/$rid/runtimes
-  if [ -d "$output_path/$rid/arbitrum-tmp/runtimes" ]; then
-    cp -r $output_path/$rid/arbitrum-tmp/runtimes/. $output_path/$rid/runtimes/
-    if ! find "$output_path/$rid/runtimes" -name "*stylus*" -print -quit | grep -q .; then
-      echo "ERROR: No Stylus native libraries were copied for $rid"
-      exit 1
-    fi
-  else
+  # `dotnet publish -r <rid>` flattens the matching RID's native assets
+  # (runtimes/<rid>/native/libstylus.*) into the publish root, so the files
+  # are picked up there and placed back into the runtimes/<rid>/native layout
+  # the .NET host adds to the native library search path at startup.
+  native_dir=$output_path/$rid/runtimes/$rid/native
+  mkdir -p "$native_dir"
+  shopt -s nullglob
+  stylus_libs=("$output_path/$rid/arbitrum-tmp"/*stylus*)
+  shopt -u nullglob
+  if [ ${#stylus_libs[@]} -eq 0 ]; then
     echo "ERROR: Stylus native libraries not found for $rid"
     exit 1
   fi
+  cp "${stylus_libs[@]}" "$native_dir/"
 
   # Copy Arbitrum configs and chainspecs
   mkdir -p $output_path/$rid/configs $output_path/$rid/chainspec

--- a/scripts/build/build.sh
+++ b/scripts/build/build.sh
@@ -26,11 +26,12 @@ for rid in "linux-arm64" "linux-x64" "osx-arm64" "win-x64"; do
     -p:PublishSingleFile=true \
     -p:SourceRevisionId=$1
 
-  # Restore Arbitrum plugin dependencies for the specific RID
-  dotnet restore src/Nethermind.Arbitrum/Nethermind.Arbitrum.csproj \
-    -r $rid
-
-  # Build Arbitrum plugin (not self-contained, will use runner's runtime)
+  # Build Arbitrum plugin (not self-contained, will use runner's runtime).
+  # The upfront --locked-mode restore already populated assets for every RID
+  # listed in Nethermind.Arbitrum's <RuntimeIdentifiers>; a per-RID restore
+  # here would traverse the Nethermind.Runner project reference and rewrite
+  # Runner's project.assets.json with only the current RID, breaking
+  # subsequent loop iterations.
   dotnet publish src/Nethermind.Arbitrum/Nethermind.Arbitrum.csproj \
     -c $build_config -r $rid -o $output_path/$rid/arbitrum-tmp --no-restore --sc false \
     -p:SourceRevisionId=$1

--- a/scripts/build/build.sh
+++ b/scripts/build/build.sh
@@ -9,8 +9,11 @@ output_path=/nethermind/output
 
 echo "Building Nethermind Arbitrum"
 
-# Restore dependencies
-dotnet restore src/Nethermind.Arbitrum/Nethermind.Arbitrum.csproj --locked-mode
+# Restore dependencies. Pass PublishReadyToRun so the SDK fetches R2R platform
+# packs (crossgen2, runtime packs) for every RID listed in Nethermind.Runner's
+# <RuntimeIdentifiers>. Staying in --locked-mode preserves reproducibility —
+# platform packs are determined by the pinned SDK image, not the lock file.
+dotnet restore src/Nethermind.Arbitrum/Nethermind.Arbitrum.csproj --locked-mode -p:PublishReadyToRun=true
 
 for rid in "linux-arm64" "linux-x64" "osx-arm64" "win-x64"; do
   echo "  Publishing for $rid"

--- a/src/Nethermind.Arbitrum/Nethermind.Arbitrum.csproj
+++ b/src/Nethermind.Arbitrum/Nethermind.Arbitrum.csproj
@@ -14,6 +14,7 @@
     <ArbitrumConfigsDir>Properties</ArbitrumConfigsDir>
     <ArbitrumNativeLibrariesDir>runtimes</ArbitrumNativeLibrariesDir>
     <RunnerProjectRelativePath>..\Nethermind\src\Nethermind\Nethermind.Runner\Nethermind.Runner.csproj</RunnerProjectRelativePath>
+    <RuntimeIdentifiers>linux-arm64;linux-x64;osx-arm64;win-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

The `release/0.2.0` Docker build was failing with `ERROR: Stylus native libraries not found for linux-arm64` (see [run 25751373175](https://github.com/NethermindEth/nethermind-arbitrum/actions/runs/25751373175/job/75628265387)). The branch was missing the three build-script fixes that landed on `release/0.1.2` after it diverged. This PR ports them.

Cherry-picked in order:

- `7b81413` — **fix(build): enable R2R platform packs on the locked restore.** Pass `-p:PublishReadyToRun=true` to the upfront restore so the SDK fetches crossgen2 / runtime packs for every RID in `Nethermind.Runner`'s `<RuntimeIdentifiers>`, while staying in `--locked-mode`.
- `9718560` — **fix(build): pick up flattened Stylus native libs from publish root.** `dotnet publish -r <rid> --no-self-contained` flattens `runtimes/<rid>/native/libstylus.*` into the publish root. Glob `*stylus*` from there and place files back into the `runtimes/<rid>/native/` layout the .NET host expects. This is the direct fix for the linux-arm64 failure.
- `dad64b2` — **fix(build): restore Arbitrum for every RID upfront, drop in-loop restore.** The per-RID `dotnet restore Nethermind.Arbitrum.csproj -r <rid>` inside the loop traversed the Nethermind.Runner project reference and rewrote Runner's `project.assets.json` with only the current RID, breaking subsequent iterations with `NETSDK1047`. Declare `<RuntimeIdentifiers>` on `Nethermind.Arbitrum.csproj` so the single upfront `--locked-mode` restore populates assets for both projects in one pass.

The 0.1.2-side NU1903 / Snappier fix is **not** needed here: 0.2.0's submodule is at NM 1.38.0, which already ships Snappier 1.3.1.

## Test plan

- [x] `dotnet restore src/Nethermind.Arbitrum/Nethermind.Arbitrum.csproj --locked-mode -p:PublishReadyToRun=true` succeeds locally with no NU/SDK errors.
- [ ] Re-run the Release workflow on this branch and confirm Docker build completes for all four RIDs (`linux-arm64`, `linux-x64`, `osx-arm64`, `win-x64`).
- [ ] Confirm the resulting image contains `runtimes/<rid>/native/libstylus.*` for the target RID and that `nethermind` launches and reports a version.