### PR TITLE
Shutdown on failure to parse incoming L2 message

### DIFF
--- a/src/Nethermind.Arbitrum.Test/Rpc/DigestMessage/NitroL2MessageParserTests.cs
+++ b/src/Nethermind.Arbitrum.Test/Rpc/DigestMessage/NitroL2MessageParserTests.cs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: https://github.com/NethermindEth/nethermind-arbitrum/blob/main/LICENSE.md
 
-using System.Text;
-using System.Text.Json;
 using FluentAssertions;
 using Nethermind.Arbitrum.Arbos;
 using Nethermind.Arbitrum.Config;
@@ -12,12 +10,17 @@ using Nethermind.Arbitrum.Execution.Transactions;
 using Nethermind.Arbitrum.Precompiles;
 using Nethermind.Arbitrum.Precompiles.Abi;
 using Nethermind.Arbitrum.Test.Infrastructure;
+using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Int256;
 using Nethermind.Specs.ChainSpecStyle;
 using Nethermind.Specs.Test.ChainSpecStyle;
+using NSubstitute;
+using System.Text;
+using System.Text.Json;
+using Nethermind.Logging;
 using static NUnit.Framework.Assert;
 
 namespace Nethermind.Arbitrum.Test.Rpc.DigestMessage;
@@ -44,7 +47,7 @@ public class NitroL2MessageParserTests
             Convert.FromBase64String("AAAAAAAAAAAAAAAAP6sYRiLcGbYQk0m5SBFJO/KkU2IAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAI4byb8EAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAjmgvhUZ1IAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGTUgAAAAAAAAAAAAAAACTtMEUtA7PH8NHRUAKG5uRFcNOQgAAAAAAAAAAAAAAAJO0wRS0Ds8fw0dFQAobm5EVw05CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAO5rKAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
             null, null);
 
-        ArbitrumSubmitRetryableTransaction transaction = (ArbitrumSubmitRetryableTransaction)NitroL2MessageParser.ParseTransactions(message, ChainId, ArbosVersion.Forty, new()).Single();
+        ArbitrumSubmitRetryableTransaction transaction = (ArbitrumSubmitRetryableTransaction)NitroL2MessageParser.ParseTransactions(message, ChainId, ArbosVersion.Forty, Substitute.For<IProcessExitSource>(), new()).Single();
 
         ArbitrumSubmitRetryableTransaction expectedTransaction = new()
         {
@@ -89,7 +92,7 @@ public class NitroL2MessageParserTests
             Convert.FromBase64String("BPilgIUXSHboAIMBhqCAgLhTYEWAYA5gADmAYADzUP5//////////////////////////////////////////+A2AWAAgWAggjeANYKCNPWAFRVgOVeBgv1bgIJSUFBQYBRgDPMboCIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIioCIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIi"),
             null, null);
 
-        Transaction transaction = NitroL2MessageParser.ParseTransactions(message, ChainId, ArbosVersion.Forty, new()).Single();
+        Transaction transaction = NitroL2MessageParser.ParseTransactions(message, ChainId, ArbosVersion.Forty, Substitute.For<IProcessExitSource>(), new()).Single();
 
         transaction.Should().BeEquivalentTo(new Transaction
         {
@@ -122,7 +125,7 @@ public class NitroL2MessageParserTests
             Convert.FromBase64String("Px6ufUbYjwj8L47Sf8sqsYPrLQ4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAFS0Cx+FK9oAAAA=="),
             null, null);
 
-        ArbitrumDepositTransaction transaction = (ArbitrumDepositTransaction)NitroL2MessageParser.ParseTransactions(message, ChainId, ArbosVersion.Forty, new()).Single();
+        ArbitrumDepositTransaction transaction = (ArbitrumDepositTransaction)NitroL2MessageParser.ParseTransactions(message, ChainId, ArbosVersion.Forty, Substitute.For<IProcessExitSource>(), new()).Single();
 
         ArbitrumDepositTransaction expectedTransaction = new()
         {
@@ -150,14 +153,14 @@ public class NitroL2MessageParserTests
             new(
                 ArbitrumL1MessageKind.L2Message,
                 new Address("0xA4b000000000000000000073657175656e636572"),
-                166,
+                166,    
                 1745999257,
                 null,
                 8),
             Convert.FromBase64String("BAL4doMGSrqAhFloLwCEZVPxAIJSCJReFJfdHwjIey2P4j6aq2wd6DPZJ4kFa8deLWMQAACAwICgTJ7ERDhsUJoSmXYhVhdHIN5YgHJ2PBS1e9YImp0iAfmgTkKAGg0ukQ/BHPiMnbTpFqIuHlSBgQff7dPFFlMlhP4="),
             null, null);
 
-        Transaction transaction = NitroL2MessageParser.ParseTransactions(message, ChainId, ArbosVersion.Forty, new()).Single();
+        Transaction transaction = NitroL2MessageParser.ParseTransactions(message, ChainId, ArbosVersion.Forty, Substitute.For<IProcessExitSource>(), new()).Single();
 
         transaction.Should().BeEquivalentTo(new Transaction
         {
@@ -197,7 +200,7 @@ public class NitroL2MessageParserTests
             Convert.FromBase64String(l2Msg),
             batchDataCost, null);
 
-        ArbitrumInternalTransaction transaction = (ArbitrumInternalTransaction)NitroL2MessageParser.ParseTransactions(message, ChainId, ArbosVersion.Forty, new()).Single();
+        ArbitrumInternalTransaction transaction = (ArbitrumInternalTransaction)NitroL2MessageParser.ParseTransactions(message, ChainId, ArbosVersion.Forty, Substitute.For<IProcessExitSource>(), new()).Single();
 
         byte[] packedData = ArbosActsCodec.PackInput(ArbosActsMethod.BatchPostingReport, batchTimestamp, batchPosterAddr, 1, batchDataCost,
             l1BaseFee);
@@ -234,7 +237,7 @@ public class NitroL2MessageParserTests
             Convert.FromBase64String("AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABMLAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACPDRgAAAAAAAAAAAAAAAAARtX/jSFhPBC5DbGv3w8Pe8XHeSQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0J3gig=="),
             null, null);
 
-        IReadOnlyList<Transaction> transactions = NitroL2MessageParser.ParseTransactions(message, ChainId, ArbosVersion.Forty, new());
+        IReadOnlyList<Transaction> transactions = NitroL2MessageParser.ParseTransactions(message, ChainId, ArbosVersion.Forty, Substitute.For<IProcessExitSource>(), new());
         ArbitrumDepositTransaction deposit = (ArbitrumDepositTransaction)transactions[0];
         ArbitrumContractTransaction contract = (ArbitrumContractTransaction)transactions[1];
 
@@ -290,7 +293,7 @@ public class NitroL2MessageParserTests
             emptyL2MsgBytes,
             null, null);
 
-        IReadOnlyList<Transaction> transactions = NitroL2MessageParser.ParseTransactions(message, ChainId, ArbosVersion.Forty, new());
+        IReadOnlyList<Transaction> transactions = NitroL2MessageParser.ParseTransactions(message, ChainId, ArbosVersion.Forty, Substitute.For<IProcessExitSource>(), new());
 
         transactions.Should().BeEmpty();
     }
@@ -520,7 +523,7 @@ public class NitroL2MessageParserTests
             BatchGasCost: null,
             BatchDataStats: batchDataStats);
 
-        IReadOnlyList<Transaction> transactions = NitroL2MessageParser.ParseTransactions(message, ChainId, ArbosVersion.Forty, new());
+        IReadOnlyList<Transaction> transactions = NitroL2MessageParser.ParseTransactions(message, ChainId, ArbosVersion.Forty, Substitute.For<IProcessExitSource>(), new());
 
         transactions.Should().NotBeEmpty("Parser should successfully parse with BatchDataStats present");
 
@@ -567,7 +570,7 @@ public class NitroL2MessageParserTests
             BatchGasCost: null,
             BatchDataStats: null);
 
-        IReadOnlyList<Transaction> transactions = NitroL2MessageParser.ParseTransactions(message, ChainId, ArbosVersion.Forty, new());
+        IReadOnlyList<Transaction> transactions = NitroL2MessageParser.ParseTransactions(message, ChainId, ArbosVersion.Forty, Substitute.For<IProcessExitSource>(), new());
 
         transactions.Should().BeEmpty("Parser should return empty when both BatchGasCost and BatchDataStats are null");
     }
@@ -606,7 +609,7 @@ public class NitroL2MessageParserTests
             BatchGasCost: null,
             BatchDataStats: batchDataStats);
 
-        IReadOnlyList<Transaction> transactions = NitroL2MessageParser.ParseTransactions(message, ChainId, 50, new());
+        IReadOnlyList<Transaction> transactions = NitroL2MessageParser.ParseTransactions(message, ChainId, 50, Substitute.For<IProcessExitSource>(), new());
 
         transactions.Should().NotBeEmpty();
         ArbitrumInternalTransaction transaction = (ArbitrumInternalTransaction)transactions.Single();
@@ -657,7 +660,7 @@ public class NitroL2MessageParserTests
             BatchGasCost: null,
             BatchDataStats: batchDataStats);
 
-        IReadOnlyList<Transaction> transactions = NitroL2MessageParser.ParseTransactions(message, ChainId, 50, new());
+        IReadOnlyList<Transaction> transactions = NitroL2MessageParser.ParseTransactions(message, ChainId, 50, Substitute.For<IProcessExitSource>(), new());
 
         transactions.Should().NotBeEmpty();
         ArbitrumInternalTransaction transaction = (ArbitrumInternalTransaction)transactions.Single();
@@ -677,7 +680,7 @@ public class NitroL2MessageParserTests
     }
 
     [Test]
-    public static void ParseBatchPostingReport_WhenArbOS50WithoutBatchDataStats_ReturnsEmpty()
+    public static void ParseBatchPostingReport_WhenArbOS50WithoutBatchDataStats_ExitsProcess()
     {
         ulong batchTimestamp = 1745999275;
         Address batchPosterAddr = new("0xe2148eE53c0755215Df69b2616E552154EdC584f");
@@ -706,8 +709,10 @@ public class NitroL2MessageParserTests
             BatchGasCost: null,
             BatchDataStats: null);
 
-        IReadOnlyList<Transaction> transactions = NitroL2MessageParser.ParseTransactions(message, ChainId, 50, new());
+        IProcessExitSource testExitSource = Substitute.For<IProcessExitSource>();
+        IReadOnlyList<Transaction> transactions = NitroL2MessageParser.ParseTransactions(message, ChainId, ArbosVersion.Fifty, testExitSource, LimboTraceLogger.Instance);
 
+        testExitSource.Received().Exit(ExitCodes.GeneralError);
         transactions.Should().BeEmpty("Parser should return empty when BatchDataStats is missing for ArbOS >= 50");
     }
 

--- a/src/Nethermind.Arbitrum.Test/Rpc/DigestMessage/NitroL2MessageParserTests.cs
+++ b/src/Nethermind.Arbitrum.Test/Rpc/DigestMessage/NitroL2MessageParserTests.cs
@@ -153,7 +153,7 @@ public class NitroL2MessageParserTests
             new(
                 ArbitrumL1MessageKind.L2Message,
                 new Address("0xA4b000000000000000000073657175656e636572"),
-                166,    
+                166,
                 1745999257,
                 null,
                 8),

--- a/src/Nethermind.Arbitrum.Test/Rpc/DigestMessage/NitroL2MessageSerializerTests.cs
+++ b/src/Nethermind.Arbitrum.Test/Rpc/DigestMessage/NitroL2MessageSerializerTests.cs
@@ -1,15 +1,17 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: https://github.com/NethermindEth/nethermind-arbitrum/blob/main/LICENSE.md
 
-using System.Text.Json;
 using FluentAssertions;
 using Nethermind.Arbitrum.Data;
 using Nethermind.Arbitrum.Data.Transactions;
 using Nethermind.Arbitrum.Execution.Transactions;
 using Nethermind.Arbitrum.Test.Infrastructure;
+using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Logging;
 using Nethermind.Serialization.Json;
+using NSubstitute;
+using System.Text.Json;
 
 namespace Nethermind.Arbitrum.Test.Rpc.DigestMessage;
 
@@ -32,7 +34,7 @@ public class NitroL2MessageSerializerTests
             if (parameters.Message.Message.Header.Kind == ArbitrumL1MessageKind.BatchPostingReport)
                 continue;
 
-            IReadOnlyList<Transaction> transactions = NitroL2MessageParser.ParseTransactions(parameters.Message.Message, chainConfig.ChainId, 40, new ILogger());
+            IReadOnlyList<Transaction> transactions = NitroL2MessageParser.ParseTransactions(parameters.Message.Message, chainConfig.ChainId, 40, Substitute.For<IProcessExitSource>(), new ILogger());
             byte[] serialized = NitroL2MessageSerializer.SerializeTransactions(transactions, parameters.Message.Message.Header);
 
             parameters.Message.Message.L2Msg.Should().BeEquivalentTo(serialized, o => o.WithStrictOrdering());

--- a/src/Nethermind.Arbitrum.Test/Sequencer/UserTxSequencingTests.cs
+++ b/src/Nethermind.Arbitrum.Test/Sequencer/UserTxSequencingTests.cs
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: https://github.com/NethermindEth/nethermind-arbitrum/blob/main/LICENSE.md
 
-using System.Text.Json;
 using FluentAssertions;
+using Nethermind.Arbitrum.Config;
 using Nethermind.Arbitrum.Data;
 using Nethermind.Arbitrum.Data.Transactions;
-using Nethermind.Arbitrum.Config;
 using Nethermind.Arbitrum.Sequencer;
 using Nethermind.Arbitrum.Sequencer.Queues;
 using Nethermind.Arbitrum.Sequencer.Timeboost;
 using Nethermind.Arbitrum.Test.Infrastructure;
+using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
@@ -17,6 +17,8 @@ using Nethermind.Core.Test.Builders;
 using Nethermind.JsonRpc;
 using Nethermind.Logging;
 using Nethermind.Serialization.Rlp;
+using NSubstitute;
+using System.Text.Json;
 
 namespace Nethermind.Arbitrum.Test.Sequencer;
 
@@ -41,7 +43,7 @@ public class UserTxSequencingTests
             [Rlp.Encode(tx).Bytes], 0, timestamp, 1);
 
         IReadOnlyList<Transaction> parsed = NitroL2MessageParser.ParseTransactions(
-            assembled.Message, FullChainSimulationChainSpecProvider.ChainId, 20, LimboLogs.Instance.GetClassLogger<UserTxSequencingTests>());
+            assembled.Message, FullChainSimulationChainSpecProvider.ChainId, 20, Substitute.For<IProcessExitSource>(), LimboLogs.Instance.GetClassLogger<UserTxSequencingTests>());
 
         parsed.Should().HaveCount(1);
         parsed[0].To.Should().Be(tx.To!);
@@ -79,7 +81,7 @@ public class UserTxSequencingTests
             [Rlp.Encode(tx1).Bytes, Rlp.Encode(tx2).Bytes], 0, timestamp, 1);
 
         IReadOnlyList<Transaction> parsed = NitroL2MessageParser.ParseTransactions(
-            assembled.Message, FullChainSimulationChainSpecProvider.ChainId, 20, LimboLogs.Instance.GetClassLogger<UserTxSequencingTests>());
+            assembled.Message, FullChainSimulationChainSpecProvider.ChainId, 20, Substitute.For<IProcessExitSource>(), LimboLogs.Instance.GetClassLogger<UserTxSequencingTests>());
 
         parsed.Should().HaveCount(2);
         parsed[0].To.Should().Be(tx1.To!);

--- a/src/Nethermind.Arbitrum/Config/ArbitrumBlockProducerTxSourceFactory.cs
+++ b/src/Nethermind.Arbitrum/Config/ArbitrumBlockProducerTxSourceFactory.cs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: https://github.com/NethermindEth/nethermind-arbitrum/blob/main/LICENSE.md
 
 using Nethermind.Arbitrum.Execution.Transactions;
+using Nethermind.Config;
 using Nethermind.Consensus.Producers;
 using Nethermind.Consensus.Transactions;
 using Nethermind.Core.Specs;
@@ -9,10 +10,10 @@ using Nethermind.Logging;
 
 namespace Nethermind.Arbitrum.Config;
 
-public class ArbitrumBlockProducerTxSourceFactory(ISpecProvider chainSpec, ILogManager logManager) : IBlockProducerTxSourceFactory
+public class ArbitrumBlockProducerTxSourceFactory(ISpecProvider chainSpec, IProcessExitSource processExitSource, ILogManager logManager) : IBlockProducerTxSourceFactory
 {
     public ITxSource Create()
     {
-        return new ArbitrumPayloadTxSource(chainSpec, logManager.GetClassLogger<ArbitrumPayloadTxSource>());
+        return new ArbitrumPayloadTxSource(chainSpec, processExitSource, logManager.GetClassLogger<ArbitrumPayloadTxSource>());
     }
 }

--- a/src/Nethermind.Arbitrum/Data/Transactions/NitroL2MessageParser.cs
+++ b/src/Nethermind.Arbitrum/Data/Transactions/NitroL2MessageParser.cs
@@ -5,6 +5,7 @@ using Nethermind.Arbitrum.Arbos;
 using Nethermind.Arbitrum.Execution.Transactions;
 using Nethermind.Arbitrum.Math;
 using Nethermind.Arbitrum.Precompiles;
+using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
@@ -16,7 +17,7 @@ namespace Nethermind.Arbitrum.Data.Transactions;
 
 public static class NitroL2MessageParser
 {
-    public static IReadOnlyList<Transaction> ParseTransactions(L1IncomingMessage message, ulong chainId, ulong lastArbosVersion, ILogger logger)
+    public static IReadOnlyList<Transaction> ParseTransactions(L1IncomingMessage message, ulong chainId, ulong lastArbosVersion, IProcessExitSource processExitSource, ILogger logger)
     {
         if (message.L2Msg is null || message.L2Msg.Length == 0)
         {
@@ -71,8 +72,10 @@ public static class NitroL2MessageParser
         }
         catch (Exception ex)
         {
-            if (logger.IsWarn)
-                logger.Warn($"Error parsing incoming messages for: {message.Header.Kind} - {ex}");
+            if (logger.IsError)
+                logger.Error($"Error parsing incoming messages for: {message.Header.Kind} - {ex} - shutting down");
+
+            processExitSource.Exit(ExitCodes.GeneralError);
             return [];
         }
     }

--- a/src/Nethermind.Arbitrum/Execution/Transactions/ArbitrumRpcTxSource.cs
+++ b/src/Nethermind.Arbitrum/Execution/Transactions/ArbitrumRpcTxSource.cs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: https://github.com/NethermindEth/nethermind-arbitrum/blob/main/LICENSE.md
 
 using Nethermind.Arbitrum.Data.Transactions;
+using Nethermind.Config;
 using Nethermind.Consensus.Producers;
 using Nethermind.Consensus.Transactions;
 using Nethermind.Core;
@@ -24,7 +25,7 @@ public class ArbitrumRpcTxSource(ILogManager logManager) : ITxSource
     }
 }
 
-public class ArbitrumPayloadTxSource(ISpecProvider specProvider, ILogger logger) : ITxSource
+public class ArbitrumPayloadTxSource(ISpecProvider specProvider, IProcessExitSource processExitSource, ILogger logger) : ITxSource
 {
     public bool SupportsBlobs => false;
 
@@ -33,9 +34,8 @@ public class ArbitrumPayloadTxSource(ISpecProvider specProvider, ILogger logger)
         if (logger.IsTrace)
             logger.Trace($"Getting L2 transactions for block {parent.Number}, gas limit {gasLimit}");
 
-        if (payloadAttributes is ArbitrumPayloadAttributes arbitrumPayloadAttributes)
-            if (arbitrumPayloadAttributes.MessageWithMetadata != null)
-                return NitroL2MessageParser.ParseTransactions(arbitrumPayloadAttributes.MessageWithMetadata.Message, specProvider.ChainId, arbitrumPayloadAttributes.PreviousArbosVersion, logger);
+        if (payloadAttributes is ArbitrumPayloadAttributes { MessageWithMetadata: not null } arbitrumPayloadAttributes)
+            return NitroL2MessageParser.ParseTransactions(arbitrumPayloadAttributes.MessageWithMetadata.Message, specProvider.ChainId, arbitrumPayloadAttributes.PreviousArbosVersion, processExitSource, logger);
 
         return [];
     }


### PR DESCRIPTION
When `ParseTransactions` fails to parse incoming L2 message, it only gives a warning and returns an empty list of transactions. In a specific case:
- no gas data stats in a batch posting report post arbos 50

this can lead to creation of an invalid block (with omitted transactions), which is found only if `VerifyBlockHash` is enabled, but depending on the configured frequency it can be difficult to recover the node.

This change converts warning into terminal error which shuts down the node to avoid state database corruption.