### PR TITLE
No check for gas model during multi gas refund

### DIFF
--- a/src/Nethermind.Arbitrum/Execution/ArbitrumTransactionProcessor.cs
+++ b/src/Nethermind.Arbitrum/Execution/ArbitrumTransactionProcessor.cs
@@ -1425,10 +1425,6 @@ namespace Nethermind.Arbitrum.Execution
             if (_arbosState!.CurrentArbosVersion < ArbosVersion.MultiGasConstraintsVersion)
                 return;
 
-            GasModel gasModel = _arbosState.L2PricingState.GetGasModelToUse();
-            if (gasModel != GasModel.MultiGasConstraints)
-                return;
-
             // Calculate the actual cost based on per-resource base fees
             UInt256 multiDimensionalCost = _arbosState.L2PricingState.MultiDimensionalPriceForRefund(
                 TxExecContext.AccumulatedMultiGas);


### PR DESCRIPTION
Looks like model check is not done prior to muli-gas refund:
https://github.com/OffchainLabs/nitro/blob/335e2aee369c8e78691dea62aa28c8551190ddd6/arbos/tx_processor.go#L789
and refund is done anyway.